### PR TITLE
add new useClipboard hook, hook up copy address buttons

### DIFF
--- a/packages/client/src/components/SafeContacts.js
+++ b/packages/client/src/components/SafeContacts.js
@@ -1,7 +1,10 @@
 import React from "react";
 import { Person } from "./Svg";
+import useClipboard from "../hooks/useClipboard";
 
 function SafeContacts({ safeOwners = [] }) {
+  const clipboard = useClipboard();
+
   return (
     <>
       <div className="column p-0 mt-5 is-flex is-full">
@@ -22,7 +25,12 @@ function SafeContacts({ safeOwners = [] }) {
             <div className="flex-2">{so.address}</div>
             <div className="is-underlined">
               <span className="mr-5">Edit</span>
-              <span className="mr-5">Copy Address</span>
+              <span
+                className="mr-5 pointer"
+                onClick={() => clipboard.copy(so.address)}
+              >
+                {clipboard.didCopy ? "Copied" : "Copy Address"}
+              </span>
               <span>Send</span>
             </div>
           </div>

--- a/packages/client/src/components/SafeSettings.js
+++ b/packages/client/src/components/SafeSettings.js
@@ -1,4 +1,5 @@
 import React from "react";
+import useClipboard from "../hooks/useClipboard";
 
 const SignatureBar = ({ threshold, safeOwners }) => (
   <div className="is-flex column p-0 is-full">
@@ -16,6 +17,8 @@ const SignatureBar = ({ threshold, safeOwners }) => (
 );
 
 function SafeSettings({ address, name, threshold, safeOwners }) {
+  const clipboard = useClipboard();
+
   return (
     <>
       <div className="column p-0 mt-5 is-flex is-full">
@@ -73,7 +76,12 @@ function SafeSettings({ address, name, threshold, safeOwners }) {
             </div>
             <div className="flex-1">{so.address}</div>
             <div>
-              <span className="is-underlined mr-5">Copy Address</span>
+              <span
+                className="is-underlined mr-5 pointer"
+                onClick={() => clipboard.copy(so.address)}
+              >
+                {clipboard.didCopy ? "Copied" : "Copy Address"}
+              </span>
               <span className="is-underlined">Edit</span>
             </div>
           </div>

--- a/packages/client/src/hooks/useClipboard.js
+++ b/packages/client/src/hooks/useClipboard.js
@@ -1,0 +1,59 @@
+import { useCallback, useRef, useState, useEffect } from "react";
+
+function useTimedToggle(initialValue) {
+  const [value, setValue] = useState(false);
+  const timeoutRef = useRef();
+  const initialValueRef = useRef(initialValue);
+
+  const toggleValue = (timeout) => {
+    clearTimeout(timeoutRef.current);
+    setValue(!initialValueRef.current);
+
+    timeoutRef.current = window.setTimeout(
+      () => setValue(initialValueRef.current),
+      timeout
+    );
+  };
+
+  useEffect(() => () => clearTimeout(timeoutRef.current), []);
+
+  return [value, toggleValue];
+}
+
+export default function useClipboard({
+  copiedTimeout = 2000,
+  onSuccess,
+  onError,
+} = {}) {
+  const [didCopy, setCopied] = useTimedToggle(false);
+
+  const copyHandler = useCallback(
+    (text) => {
+      function handleSuccess() {
+        onSuccess?.();
+        setCopied(copiedTimeout);
+      }
+
+      function handleError() {
+        onError?.();
+      }
+
+      async function copy(value) {
+        navigator.clipboard
+          .writeText(value)
+          .then(handleSuccess)
+          .catch(handleError);
+      }
+
+      if (typeof text === "string") {
+        copy(text);
+      }
+    },
+    [copiedTimeout, onSuccess, onError, setCopied]
+  );
+
+  return {
+    didCopy,
+    copy: copyHandler,
+  };
+}

--- a/packages/client/src/pages/Safe.js
+++ b/packages/client/src/pages/Safe.js
@@ -12,9 +12,11 @@ import {
 } from "../components";
 import { ArrowDown, ArrowUp } from "../components/Svg";
 import { Web3Consumer, useModalContext } from "../contexts";
+import useClipboard from "../hooks/useClipboard";
 
 const ReceiveTokens = ({ name, address }) => {
   const modalContext = useModalContext();
+  const clipboard = useClipboard();
 
   return (
     <div className="p-5 has-text-black has-text-centered">
@@ -29,7 +31,12 @@ const ReceiveTokens = ({ name, address }) => {
       </div>
       <div className="border-light-top mt-5 pt-6">
         <QRCode value={`https://flowscan.org/account/${address}`} />
-        <div className="is-underlined mt-5">Copy Safe Address</div>
+        <div
+          className="is-underlined mt-5 pointer"
+          onClick={() => clipboard.copy(address)}
+        >
+          {clipboard.didCopy ? "Copied" : "Copy Safe Address"}
+        </div>
       </div>
       <div className="is-flex is-align-items-center mt-6">
         <button
@@ -152,6 +159,7 @@ function Safe({ web3 }) {
   const params = useParams();
   const { address, tab } = params;
   const modalContext = useModalContext();
+  const clipboard = useClipboard();
 
   const safeData = web3?.treasuries?.[address];
   if (!safeData) {
@@ -227,7 +235,17 @@ function Safe({ web3 }) {
     <section className="section is-flex is-flex-direction-column has-text-black">
       <div className="column is-full p-0 is-flex is-flex-direction-column mb-5">
         <h2 className="is-size-4 mb-2">{safeData.name}</h2>
-        <p className="has-text-grey">Safe address {shortenAddr(address)}</p>
+        <p>
+          <span className="has-text-grey">
+            Safe address {shortenAddr(address)}
+          </span>
+          <span
+            className="is-underlined ml-2 pointer"
+            onClick={() => clipboard.copy(address)}
+          >
+            {clipboard.didCopy ? "Copied" : "Copy address"}
+          </span>
+        </p>
       </div>
       <div className="column is-full p-0 is-flex is-align-items-center">
         <div className="is-flex">{ButtonCpts}</div>


### PR DESCRIPTION
I couldn't find a corresponding Linear task for this, but let me know if there is one / if one should be made.

- `useClipboard` hook is a simplified, dependency-less version of [this](https://github.com/wsmd/use-clipboard-copy) library
- I opted to use [`navigator.clipboard`](https://caniuse.com/?search=navigator.clipboard), but let me know if browser support is a concern (I would assume IE is a non-issue)
- The interstitial text is just "Copied" right now, happy to change that if there's something else it should be
- I did add one new location that I saw in the Figma mocks but not the current app:

<img width="666" alt="Screen Shot 2022-05-15 at 6 00 57 PM" src="https://user-images.githubusercontent.com/2916671/168495751-668d47e5-197a-42b5-a02b-383b13fb0038.png">

Let me know if I missed any spots, or if any other new ones should be added!