### PR TITLE
add required asterisk to more fields, fix an input placeholder

### DIFF
--- a/packages/client/src/components/SafeOwners.js
+++ b/packages/client/src/components/SafeOwners.js
@@ -17,7 +17,9 @@ function SafeOwners({ address, safeOwners, setSafeOwners }) {
   let safeOwnerCpts = [
     <div className="column is-flex is-full" key={address}>
       <div className="flex-1 is-flex is-flex-direction-column pr-5">
-        <label className="has-text-grey mb-2">Owner Name</label>
+        <label className="has-text-grey mb-2">
+          Owner Name<span className="has-text-red">*</span>
+        </label>
         <input
           className="p-4 rounded-sm"
           type="text"
@@ -45,7 +47,9 @@ function SafeOwners({ address, safeOwners, setSafeOwners }) {
       safeOwnerCpts.push(
         <div className="column is-flex is-full" key={`extra-owner-${idx}`}>
           <div className="flex-1 is-flex is-flex-direction-column pr-5">
-            <label className="has-text-grey mb-2">Owner Name</label>
+            <label className="has-text-grey mb-2">
+              Owner Name<span className="has-text-red">*</span>
+            </label>
             <input
               className="p-4 rounded-sm"
               type="text"
@@ -55,7 +59,9 @@ function SafeOwners({ address, safeOwners, setSafeOwners }) {
             />
           </div>
           <div className="flex-1 is-flex is-flex-direction-column">
-            <label className="has-text-grey mb-2">Owner Address</label>
+            <label className="has-text-grey mb-2">
+              Owner Address<span className="has-text-red">*</span>
+            </label>
             <div className="is-flex">
               <input
                 className="p-4 rounded-sm flex-1"

--- a/packages/client/src/pages/LoadSafe.js
+++ b/packages/client/src/pages/LoadSafe.js
@@ -107,7 +107,9 @@ function LoadSafe({ web3 }) {
       safeOwnerCpts.push(
         <div className="column is-flex is-full" key={so.address}>
           <div className="flex-1 is-flex is-flex-direction-column pr-5">
-            <label className="has-text-grey mb-2">Owner Name</label>
+            <label className="has-text-grey mb-2">
+              Owner Name<span className="has-text-red">*</span>
+            </label>
             <input
               className="p-4 rounded-sm"
               type="text"
@@ -166,7 +168,7 @@ function LoadSafe({ web3 }) {
           <input
             className="p-4 rounded-sm"
             type="text"
-            placeholder="Choose a local name for your safe"
+            placeholder="16-character safe address"
             value={safeAddress}
             onChange={onAddressChange}
           />


### PR DESCRIPTION
| Fix      | Screenshot |
| ----------- | ----------- |
| We require "Owner name" and "Owner address" to always be specified in terms of the form disabling, but they did not have the required asterisk like other required fields do. Added to these places. | <img width="1484" alt="Screen Shot 2022-05-15 at 6 13 35 PM" src="https://user-images.githubusercontent.com/2916671/168496132-4892253b-9463-4efa-a5ff-5eef469fb314.png">       |
| Fixed copy & pasted placeholder in load safe view   | <img width="1490" alt="Screen Shot 2022-05-15 at 6 13 23 PM" src="https://user-images.githubusercontent.com/2916671/168496133-057fbd21-7e0f-476e-bf07-58c6f60f4b6d.png">        |

Let me know if any of these changes don't make sense.