### PR TITLE
fix typo on home page, rounded background color behind sidebar

### DIFF
--- a/packages/client/src/App.sass
+++ b/packages/client/src/App.sass
@@ -3,7 +3,7 @@
 $navWidth: 260px
 
 // Set your brand colors
-$bodyBg: #11191f
+$bodyBg: #162c4e
 $bodyColor: #bbc6ce
 
 // Update Bulma's global variables
@@ -68,7 +68,7 @@ body
 .sidebar
   position: fixed
   width: $navWidth
-  background: linear-gradient(180deg, #162C4E 0%, #000C1E 100%)
+  background: linear-gradient(180deg, $bodyBg 0%, #000C1E 100%)
 .body
   width: calc(100% - #{$navWidth})
   min-height: 100vh
@@ -112,7 +112,7 @@ code
   cursor: pointer
 .is-disabled
   pointer-events: none
-  svg 
+  svg
     opacity: 0.5
 hr
   background-color: grey

--- a/packages/client/src/pages/Home.js
+++ b/packages/client/src/pages/Home.js
@@ -15,7 +15,7 @@ const SafeLinks = () => (
         Create or load a Safe to get started
       </h1>
       <p className="subtitle has-text-grey">
-        We’ll get you onboarded after you we import your data
+        We’ll get you onboarded after we import your data
       </p>
       <div className="is-flex">
         <NavLink className="has-text-black" to="/load-safe">


### PR DESCRIPTION
| Before      | After |
| ----------- | ----------- |
| <img width="1073" alt="Screen Shot 2022-05-16 at 2 48 49 PM" src="https://user-images.githubusercontent.com/2916671/168661873-02f64d22-d849-4aae-b778-5bb394c77b47.png">      | <img width="1072" alt="Screen Shot 2022-05-16 at 2 49 08 PM" src="https://user-images.githubusercontent.com/2916671/168661908-de2688d7-586c-41d5-bd51-a86eb90cbbda.png">       |

