### PR TITLE
VSL-22: hook up address copying and name editing from safe settings

### DIFF
--- a/packages/client/src/components/SafeContacts.js
+++ b/packages/client/src/components/SafeContacts.js
@@ -29,7 +29,9 @@ function SafeContacts({ safeOwners = [] }) {
                 className="mr-5 pointer"
                 onClick={() => clipboard.copy(so.address)}
               >
-                {clipboard.didCopy ? "Copied" : "Copy Address"}
+                {clipboard.textJustCopied === so.address
+                  ? "Copied"
+                  : "Copy Address"}
               </span>
               <span>Send</span>
             </div>

--- a/packages/client/src/components/SafeDetails.js
+++ b/packages/client/src/components/SafeDetails.js
@@ -21,7 +21,7 @@ const SafeDetails = ({ safeType, setSafeType, safeName, setSafeName }) => (
           Safe name<span className="has-text-red">*</span>
         </label>
         <input
-          className="p-4 rounded-sm"
+          className="p-4 rounded-sm border-light"
           type="text"
           placeholder="Choose a local name for your safe"
           value={safeName}

--- a/packages/client/src/components/SafeOwners.js
+++ b/packages/client/src/components/SafeOwners.js
@@ -26,7 +26,7 @@ function SafeOwners({
           Owner Name<span className="has-text-red">*</span>
         </label>
         <input
-          className="p-4 rounded-sm"
+          className="p-4 rounded-sm border-light"
           type="text"
           placeholder="Add a local owner name"
           value={safeOwners.find((so) => so.address === address)?.name}
@@ -61,7 +61,7 @@ function SafeOwners({
               Owner Name<span className="has-text-red">*</span>
             </label>
             <input
-              className="p-4 rounded-sm"
+              className="p-4 rounded-sm border-light"
               type="text"
               placeholder="Add a local owner name"
               value={so?.name}

--- a/packages/client/src/components/SafeSettings.js
+++ b/packages/client/src/components/SafeSettings.js
@@ -71,11 +71,11 @@ function SafeSettings({ address, web3, name, threshold, safeOwners }) {
   const modalContext = useModalContext();
   const safeAddressClipboard = useClipboard();
   const ownersAddressClipboard = useClipboard();
-  const { renameTreasury } = web3;
+  const { setTreasury } = web3;
 
   const onEditNameSubmit = (newName) => {
     modalContext.closeModal();
-    renameTreasury(address, newName);
+    setTreasury(address, { name: newName });
   };
 
   const onEditNameClick = () => {

--- a/packages/client/src/components/SafeSettings.js
+++ b/packages/client/src/components/SafeSettings.js
@@ -1,5 +1,56 @@
-import React from "react";
+import React, { useMemo, useState } from "react";
+import { useModalContext } from "../contexts";
 import { useClipboard } from "../hooks";
+
+const EditSafeName = ({ name, onCancel, onSubmit }) => {
+  const [currSafeName, setCurrSafeName] = useState(name);
+  const isNameValid = useMemo(
+    () => currSafeName.trim().length > 0,
+    [currSafeName]
+  );
+
+  const onSubmitClick = () => {
+    onSubmit(currSafeName);
+  };
+
+  const submitButtonClasses = [
+    "button flex-1 p-4",
+    isNameValid ? "is-link" : "is-light is-disabled",
+  ];
+
+  return (
+    <>
+      <div className="p-5 has-text-black">
+        <h2 className="is-size-4">Edit safe name</h2>
+        <p className="has-text-grey">Update the local name of your safe</p>
+      </div>
+      <div className="border-light-top p-5">
+        <div className="flex-1 is-flex is-flex-direction-column">
+          <label className="has-text-grey mb-2">Name</label>
+          <input
+            className="p-4 rounded-sm border-light"
+            type="text"
+            placeholder="Choose a local name for your safe"
+            value={currSafeName}
+            onChange={(e) => setCurrSafeName(e.target.value)}
+          />
+          <div className="is-flex is-align-items-center mt-6">
+            <button className="button flex-1 p-4 mr-2" onClick={onCancel}>
+              Cancel
+            </button>
+            <button
+              className={submitButtonClasses.join(" ")}
+              disabled={!isNameValid}
+              onClick={onSubmitClick}
+            >
+              Save
+            </button>
+          </div>
+        </div>
+      </div>
+    </>
+  );
+};
 
 const SignatureBar = ({ threshold, safeOwners }) => (
   <div className="is-flex column p-0 is-full">
@@ -16,8 +67,26 @@ const SignatureBar = ({ threshold, safeOwners }) => (
   </div>
 );
 
-function SafeSettings({ address, name, threshold, safeOwners }) {
-  const clipboard = useClipboard();
+function SafeSettings({ address, web3, name, threshold, safeOwners }) {
+  const modalContext = useModalContext();
+  const safeAddressClipboard = useClipboard();
+  const ownersAddressClipboard = useClipboard();
+  const { renameTreasury } = web3;
+
+  const onEditNameSubmit = (newName) => {
+    modalContext.closeModal();
+    renameTreasury(address, newName);
+  };
+
+  const onEditNameClick = () => {
+    modalContext.openModal(
+      <EditSafeName
+        name={name}
+        onCancel={() => modalContext.closeModal()}
+        onSubmit={onEditNameSubmit}
+      />
+    );
+  };
 
   return (
     <>
@@ -29,14 +98,23 @@ function SafeSettings({ address, name, threshold, safeOwners }) {
           <div className="has-text-grey">Name</div>
           <div className="mt-1 is-flex is-justify-content-space-between">
             <div>{name}</div>
-            <div className="is-underlined">Edit</div>
+            <div className="is-underlined pointer" onClick={onEditNameClick}>
+              Edit
+            </div>
           </div>
         </div>
         <div className="border-light-right pr-5 mr-5 flex-1">
           <div className="has-text-grey">Address</div>
           <div className="mt-1 is-flex is-justify-content-space-between">
             <div>{address}</div>
-            <div className="is-underlined">Copy</div>
+            <div
+              className="is-underlined pointer"
+              onClick={() => safeAddressClipboard.copy(address)}
+            >
+              {safeAddressClipboard.textJustCopied === address
+                ? "Copied"
+                : "Copy"}
+            </div>
           </div>
         </div>
         <div className="flex-1">
@@ -79,9 +157,11 @@ function SafeSettings({ address, name, threshold, safeOwners }) {
               <div>
                 <span
                   className="is-underlined mr-5 pointer"
-                  onClick={() => clipboard.copy(so.address)}
+                  onClick={() => ownersAddressClipboard.copy(so.address)}
                 >
-                  {clipboard.didCopy ? "Copied" : "Copy Address"}
+                  {ownersAddressClipboard.textJustCopied === so.address
+                    ? "Copied"
+                    : "Copy Address"}
                 </span>
                 <span className="is-underlined">Edit</span>
               </div>

--- a/packages/client/src/hooks/useTreasury.js
+++ b/packages/client/src/hooks/useTreasury.js
@@ -222,19 +222,19 @@ export default function useTreasury(treasuryAddr, userAddr) {
     return res;
   };
 
-  const setTreasury = (_treasuryAddr, treasuryData) => {
+  const setTreasury = (treasuryAddr, treasuryData) => {
     dispatch({
       type: "SET_TREASURY",
       payload: {
-        [_treasuryAddr]: treasuryData,
+        [treasuryAddr]: treasuryData,
       },
     });
   };
 
-  const fetchTreasury = async (_treasuryAddr) => {
-    const signers = await getSigners(_treasuryAddr);
+  const fetchTreasury = async (treasuryAddr) => {
+    const signers = await getSigners(treasuryAddr);
     if (signers) {
-      const threshold = await getThreshold(_treasuryAddr);
+      const threshold = await getThreshold(treasuryAddr);
       return { threshold, signers };
     }
 
@@ -279,6 +279,16 @@ export default function useTreasury(treasuryAddr, userAddr) {
     await refreshTreasury();
   };
 
+  const renameTreasury = (treasuryAddr, newName) => {
+    dispatch({
+      type: "RENAME_TREASURY",
+      payload: {
+        address: treasuryAddr,
+        name: newName,
+      },
+    });
+  };
+
   const executeAction = async (actionUUID) => {
     const res = await doExecuteAction(treasuryAddr, actionUUID);
     await tx(res).onceSealed();
@@ -293,6 +303,7 @@ export default function useTreasury(treasuryAddr, userAddr) {
     sendFlowToTreasury,
     proposeTransfer,
     signerApprove,
+    renameTreasury,
     executeAction,
   };
 }

--- a/packages/client/src/hooks/useTreasury.js
+++ b/packages/client/src/hooks/useTreasury.js
@@ -279,16 +279,6 @@ export default function useTreasury(treasuryAddr, userAddr) {
     await refreshTreasury();
   };
 
-  const renameTreasury = (treasuryAddr, newName) => {
-    dispatch({
-      type: "RENAME_TREASURY",
-      payload: {
-        address: treasuryAddr,
-        name: newName,
-      },
-    });
-  };
-
   const executeAction = async (actionUUID) => {
     const res = await doExecuteAction(treasuryAddr, actionUUID);
     await tx(res).onceSealed();
@@ -303,7 +293,6 @@ export default function useTreasury(treasuryAddr, userAddr) {
     sendFlowToTreasury,
     proposeTransfer,
     signerApprove,
-    renameTreasury,
     executeAction,
   };
 }

--- a/packages/client/src/pages/LoadSafe.js
+++ b/packages/client/src/pages/LoadSafe.js
@@ -139,7 +139,7 @@ function LoadSafe({ web3 }) {
               Owner Name<span className="has-text-red">*</span>
             </label>
             <input
-              className="p-4 rounded-sm"
+              className="p-4 rounded-sm border-light"
               type="text"
               placeholder="Add a local owner name"
               value={so.name}
@@ -187,7 +187,7 @@ function LoadSafe({ web3 }) {
             Safe Name<span className="has-text-red">*</span>
           </label>
           <input
-            className="p-4 rounded-sm"
+            className="p-4 rounded-sm border-light"
             type="text"
             placeholder="Choose a local name for your safe"
             value={safeName}

--- a/packages/client/src/pages/Safe.js
+++ b/packages/client/src/pages/Safe.js
@@ -34,7 +34,9 @@ const ReceiveTokens = ({ name, address }) => {
           className="is-underlined mt-5 pointer"
           onClick={() => clipboard.copy(address)}
         >
-          {clipboard.didCopy ? "Copied" : "Copy Safe Address"}
+          {clipboard.textJustCopied === address
+            ? "Copied"
+            : "Copy Safe Address"}
         </div>
       </div>
       <div className="is-flex is-align-items-center mt-6">
@@ -281,7 +283,12 @@ function Safe({ web3 }) {
       <SafeContacts safeOwners={safeData?.safeOwners} key="safe-contacts" />
     ),
     settings: (
-      <SafeSettings address={address} {...safeData} key="safe-settings" />
+      <SafeSettings
+        address={address}
+        web3={web3}
+        {...safeData}
+        key="safe-settings"
+      />
     ),
   };
 
@@ -289,21 +296,18 @@ function Safe({ web3 }) {
 
   const onSend = () => {
     modalContext.openModal(
-      React.createElement(SendTokens, {
-        name: safeData.name,
-        address,
-        web3,
-        balance,
-      })
+      <SendTokens
+        name={safeData.name}
+        address={address}
+        web3={web3}
+        balance={balance}
+      />
     );
   };
 
   const onReceive = () => {
     modalContext.openModal(
-      React.createElement(ReceiveTokens, {
-        name: safeData.name,
-        address,
-      })
+      <ReceiveTokens name={safeData.name} address={address} />
     );
   };
 
@@ -324,7 +328,7 @@ function Safe({ web3 }) {
             className="is-underlined ml-2 pointer"
             onClick={() => clipboard.copy(address)}
           >
-            {clipboard.didCopy ? "Copied" : "Copy address"}
+            {clipboard.textJustCopied === address ? "Copied" : "Copy address"}
           </span>
           <span className="is-underlined ml-4 pointer" onClick={onDeposit}>
             Deposit

--- a/packages/client/src/reducers/index.js
+++ b/packages/client/src/reducers/index.js
@@ -65,18 +65,6 @@ const defaultReducer = (state, action) => {
         ...state,
         createdTreasury: true,
       };
-    case "RENAME_TREASURY": {
-      return {
-        ...state,
-        treasuries: {
-          ...state.treasuries,
-          [action.payload.address]: {
-            ...state.treasuries[action.payload.address],
-            name: action.payload.name,
-          },
-        },
-      };
-    }
     case "SET_LOADING":
       return {
         ...state,

--- a/packages/client/src/reducers/index.js
+++ b/packages/client/src/reducers/index.js
@@ -65,6 +65,18 @@ const defaultReducer = (state, action) => {
         ...state,
         createdTreasury: true,
       };
+    case "RENAME_TREASURY": {
+      return {
+        ...state,
+        treasuries: {
+          ...state.treasuries,
+          [action.payload.address]: {
+            ...state.treasuries[action.payload.address],
+            name: action.payload.name,
+          },
+        },
+      };
+    }
     case "SET_LOADING":
       return {
         ...state,


### PR DESCRIPTION
- Added `border-light` to some inputs that weren't matching designs
- Refactored `useClipboard` hook to return a `textJustCopied` value instead of a boolean so that it can be used for multiple values
- Hooked up "Copy" for address in safe settings
- Added new `<EditSafeName />` modal component, hooked up to "Edit" in safe settings

https://user-images.githubusercontent.com/2916671/172436257-5193e30b-f6b7-49c6-a7d3-3b444af3d03c.mov

