### PR TITLE
VSL-43: Add Events to VESSEL Contracts

### DIFF
--- a/contracts/DAOTreasury.cdc
+++ b/contracts/DAOTreasury.cdc
@@ -11,11 +11,11 @@ pub contract DAOTreasury {
   // Events
   pub event TreasuryInitialized(initialSigners: [Address], initialThreshold: UInt64)
   pub event ProposeAction(actionUUID: UInt64)
-  pub event ExecuteAction(address: Address, actionUUID: UInt64)
-  pub event DepositVault(address: Address, vaultID: String)
-  pub event DepositCollection(address: Address, collectionID: String)
-  pub event WithdrawTokens(vaultID: String, amount: UInt64)
-  pub event WithdrawNFT(collectionID: UInt64, nftID: UInt64)
+  pub event ExecuteAction(actionUUID: UInt64)
+  pub event DepositVault(vaultID: String)
+  pub event DepositCollection(collectionID: String)
+  pub event WithdrawTokens(vaultID: String, amount: UFix64)
+  pub event WithdrawNFT(collectionID: String, nftID: UInt64)
 
 
   // Interfaces + Resources
@@ -61,6 +61,7 @@ pub contract DAOTreasury {
     pub fun executeAction(actionUUID: UInt64) {
       let selfRef: &Treasury = &self as &Treasury
       self.multiSignManager.executeAction(actionUUID: actionUUID, {"treasury": selfRef})
+      emit ExecuteAction(actionUUID: actionUUID)
     }
 
     // Reference to Manager //
@@ -82,10 +83,12 @@ pub contract DAOTreasury {
       } else {
         self.vaults[identifier] <-! vault
       }
+      emit DepositVault(vaultID: identifier)
     }
 
     // Withdraw some tokens //
     pub fun withdrawTokens(identifier: String, amount: UFix64): @FungibleToken.Vault {
+      emit WithdrawTokens(vaultID: identifier, amount: amount)
       let vaultRef = (&self.vaults[identifier] as &FungibleToken.Vault?)!
       return <- vaultRef.withdraw(amount: amount)
     }
@@ -109,11 +112,14 @@ pub contract DAOTreasury {
 
     // Deposit a Collection //
     pub fun depositCollection(collection: @NonFungibleToken.Collection) {
-      self.collections[collection.getType().identifier] <-! collection
+      let identifier = collection.getType().identifier
+      self.collections[identifier] <-! collection
+      emit DepositCollection(collectionID: identifier)
     }
 
     // Withdraw an NFT //
     pub fun withdrawNFT(identifier: String, id: UInt64): @NonFungibleToken.NFT {
+      emit WithdrawNFT(collectionID: identifier, nftID: id)
       let collectionRef = (&self.collections[identifier] as &NonFungibleToken.Collection?)!
       return <- collectionRef.withdraw(withdrawID: id)
     }

--- a/contracts/DAOTreasury.cdc
+++ b/contracts/DAOTreasury.cdc
@@ -4,9 +4,21 @@ import NonFungibleToken from "./core/NonFungibleToken.cdc"
 
 pub contract DAOTreasury {
 
+  // Storage Paths
   pub let TreasuryStoragePath: StoragePath
   pub let TreasuryPublicPath: PublicPath
 
+  // Events
+  pub event TreasuryInitialized(initialSigners: [Address], initialThreshold: UInt64)
+  pub event ProposeAction(actionUUID: UInt64)
+  pub event ExecuteAction(address: Address, actionUUID: UInt64)
+  pub event DepositVault(address: Address, vaultID: String)
+  pub event DepositCollection(address: Address, collectionID: String)
+  pub event WithdrawTokens(vaultID: String, amount: UInt64)
+  pub event WithdrawNFT(collectionID: UInt64, nftID: UInt64)
+
+
+  // Interfaces + Resources
   pub resource interface TreasuryPublic {
     pub fun proposeAction(action: {MyMultiSig.Action}): UInt64
     pub fun executeAction(actionUUID: UInt64)
@@ -27,6 +39,7 @@ pub contract DAOTreasury {
     // ------- Manager -------   
     pub fun proposeAction(action: {MyMultiSig.Action}): UInt64 {
       let uuid = self.multiSignManager.createMultiSign(action: action)
+      emit ProposeAction(actionUUID: uuid)
       return uuid
     }
 
@@ -133,6 +146,7 @@ pub contract DAOTreasury {
   }
   
   pub fun createTreasury(initialSigners: [Address], initialThreshold: UInt64): @Treasury {
+    emit TreasuryInitialized(initialSigners: initialSigners, initialThreshold: initialThreshold)
     return <- create Treasury(_initialSigners: initialSigners, _initialThreshold: initialThreshold)
   }
 

--- a/contracts/TreasuryActions.cdc
+++ b/contracts/TreasuryActions.cdc
@@ -5,6 +5,54 @@ import NonFungibleToken from "./core/NonFungibleToken.cdc"
 
 pub contract TreasuryActions {
 
+  ///////////
+  // Events
+  ///////////
+
+  // TransferToken
+  pub event TransferTokenToAccountActionCreated(
+    recipientAddr: Address, vaultID: String, amount: UFix64
+  )
+  pub event TransferTokenToAccountActionExecuted(
+    recipientAddr: Address, vaultID: String, amount: UFix64, treasuryAddr: Address
+  )
+
+  // TransferTokenToTreasury
+  pub event TransferTokenToTreasuryActionCreated(
+    recipientAddr: Address, vaultID: String, amount: UFix64
+  )
+  pub event TransferTokenToTreasuryActionExecuted(
+    recipientAddr: Address, vaultID: String, amount: UFix64, treasuryAddr: Address
+  )
+
+  // TransferNFT
+  pub event TransferNFTToAccountActionCreated(
+    recipientAddr: Address, collectionID: String, nftID: UInt64
+  )
+  pub event TransferNFTToAccountActionExecuted(
+    recipientAddr: Address, collectionID: String, nftID: UInt64, treasuryAddr: Address
+  )
+
+  // TransferNFTToTreasury
+  pub event TransferNFTToTreasuryActionCreated(
+    recipientAddr: Address, collectionID: String, nftID: UInt64
+  )
+  pub event TransferNFTToTreasuryActionExecuted(
+    recipientAddr: Address, collectionID: String, nftID: UInt64, treasuryAddr: Address
+  )
+
+  // Add Signer
+  pub event AddSignerActionCreated(address: Address)
+  pub event AddSignerActionExecuted(address: Address, treasuryAddr: Address)
+  
+  // Remove Signer
+  pub event RemoveSignerActionCreated(address: Address)
+  pub event RemoveSignerActionExecuted(address: Address, treasuryAddr: Address)
+
+  // Update Threshold
+  pub event UpdateThresholdActionCreated(threshold: UInt64)
+  pub event UpdateThresholdActionExecuted(oldThreshold: UInt64, newThreshold: UInt64, treasuryAddr: Address)
+
   // Transfers `amount` tokens from the treasury to `recipientVault`
   pub struct TransferToken: MyMultiSig.Action {
     pub let intent: String
@@ -13,10 +61,16 @@ pub contract TreasuryActions {
 
     pub fun execute(_ params: {String: AnyStruct}) {
       let treasuryRef: &DAOTreasury.Treasury = params["treasury"]! as! &DAOTreasury.Treasury
-
       let vaultRef: &FungibleToken.Vault = treasuryRef.borrowVault(identifier: self.recipientVault.borrow()!.getType().identifier)
       let withdrawnTokens <- vaultRef.withdraw(amount: self.amount)
       self.recipientVault.borrow()!.deposit(from: <- withdrawnTokens)
+
+      emit TransferTokenToAccountActionExecuted(
+        recipientAddr: self.recipientVault.borrow()!.owner!.address,
+        vaultID: self.recipientVault.getType().identifier,
+        amount: self.amount,
+        treasuryAddr: treasuryRef.owner!.address
+      )
     }
 
     init(_recipientVault: Capability<&{FungibleToken.Receiver}>, _amount: UFix64) {
@@ -28,6 +82,12 @@ pub contract TreasuryActions {
                         .concat(_recipientVault.borrow()!.owner!.address.toString())
       self.recipientVault = _recipientVault
       self.amount = _amount
+
+      emit TransferTokenToAccountActionCreated(
+        recipientAddr: _recipientVault.borrow()!.owner!.address,
+        vaultID: _recipientVault.getType().identifier,
+        amount: _amount
+      )
     }
   }
 
@@ -42,19 +102,34 @@ pub contract TreasuryActions {
       let treasuryRef: &DAOTreasury.Treasury = params["treasury"]! as! &DAOTreasury.Treasury
       let vaultRef: &FungibleToken.Vault = treasuryRef.borrowVault(identifier: self.identifier)
       let withdrawnTokens <- vaultRef.withdraw(amount: self.amount)
+      let recipientAddr = self.recipientTreasury.borrow()!.owner!.address
       self.recipientTreasury.borrow()!.depositVault(vault: <- withdrawnTokens)
+
+      emit TransferTokenToTreasuryActionExecuted(
+        recipientAddr: recipientAddr,
+        vaultID: self.identifier,
+        amount: self.amount,
+        treasuryAddr: treasuryRef.owner!.address
+      )
     }
 
     init(_recipientTreasury: Capability<&{DAOTreasury.TreasuryPublic}>, _identifier: String, _amount: UFix64) {
+      let recipientAddr = _recipientTreasury.borrow()!.owner!.address
       self.intent = "Transfer "
                         .concat(_amount.toString())
                         .concat(" ")
                         .concat(_identifier)
                         .concat(" tokens from the treasury to ")
-                        .concat(_recipientTreasury.borrow()!.owner!.address.toString())
+                        .concat(recipientAddr.toString())
       self.identifier = _identifier
       self.recipientTreasury = _recipientTreasury
       self.amount = _amount
+
+      emit TransferTokenToTreasuryActionCreated(
+        recipientAddr: recipientAddr,
+        vaultID: _identifier,
+        amount: _amount
+      )
     }
   }
 
@@ -66,19 +141,34 @@ pub contract TreasuryActions {
 
     pub fun execute(_ params: {String: AnyStruct}) {
       let treasuryRef: &DAOTreasury.Treasury = params["treasury"]! as! &DAOTreasury.Treasury
-
-      let collectionRef: &NonFungibleToken.Collection = treasuryRef.borrowCollection(identifier: self.recipientCollection.borrow()!.getType().identifier)
+      let collectionID = self.recipientCollection.borrow()!.getType().identifier
+      let collectionRef: &NonFungibleToken.Collection = treasuryRef.borrowCollection(identifier: collectionID)
       let nft <- collectionRef.withdraw(withdrawID: self.withdrawID)
       self.recipientCollection.borrow()!.deposit(token: <- nft)
+
+      emit TransferNFTToAccountActionExecuted(
+        recipientAddr: self.recipientCollection.borrow()!.owner!.address,
+        collectionID: collectionID,
+        nftID: self.withdrawID,
+        treasuryAddr: treasuryRef.owner!.address
+      )
     }
 
     init(_recipientCollection: Capability<&{NonFungibleToken.CollectionPublic}>, _nftID: UInt64) {
+      let recipientAddr = _recipientCollection.borrow()!.owner!.address
+      let collectionID = _recipientCollection.getType().identifier
+
       self.intent = "Transfer a "
-                        .concat(_recipientCollection.getType().identifier)
+                        .concat(collectionID)
                         .concat(" NFT from the treasury to ")
-                        .concat(_recipientCollection.borrow()!.uuid.toString())
+                        .concat(recipientAddr.toString())
       self.recipientCollection = _recipientCollection
       self.withdrawID = _nftID
+      emit TransferNFTToAccountActionCreated(
+        recipientAddr: recipientAddr,
+        collectionID: collectionID,
+        nftID: _nftID
+      )
     }
   }
 
@@ -96,9 +186,17 @@ pub contract TreasuryActions {
 
       let recipientCollectionRef: &{NonFungibleToken.CollectionPublic} = self.recipientTreasury.borrow()!.borrowCollectionPublic(identifier: self.identifier)
       recipientCollectionRef.deposit(token: <- nft)
+
+      emit TransferNFTToTreasuryActionExecuted(
+        recipientAddr: self.recipientTreasury.borrow()!.owner!.address,
+        collectionID: self.identifier,
+        nftID: self.withdrawID,
+        treasuryAddr: treasuryRef.owner!.address
+      )
     }
 
     init(_recipientTreasury: Capability<&{DAOTreasury.TreasuryPublic}>, _identifier: String, _nftID: UInt64) {
+      let recipientAddr = _recipientTreasury.borrow()!.owner!.address
       self.intent = "Transfer an NFT from collection"
                         .concat(" ")
                         .concat(_identifier)
@@ -106,10 +204,16 @@ pub contract TreasuryActions {
                         .concat(_nftID.toString())
                         .concat(" ")
                         .concat(" from this Treasury to Treasury at address ")
-                        .concat(_recipientTreasury.borrow()!.owner!.address.toString())
+                        .concat(recipientAddr.toString())
       self.identifier = _identifier
       self.recipientTreasury = _recipientTreasury
       self.withdrawID= _nftID
+
+      emit TransferNFTToTreasuryActionCreated(
+        recipientAddr: recipientAddr,
+        collectionID: _identifier,
+        nftID: _nftID
+      )
     }
   }
 
@@ -123,15 +227,18 @@ pub contract TreasuryActions {
 
       let manager = treasuryRef.borrowManager()
       manager.addSigner(signer: self.signer)
+
+      emit AddSignerActionExecuted(address: self.signer, treasuryAddr: treasuryRef.owner!.address)
     }
 
     init(_signer: Address) {
       self.signer = _signer
       self.intent = "Add a signer to the Treasury."
+      emit AddSignerActionCreated(address: _signer)
     }
   }
 
-    // Remove a signer from the treasury
+  // Remove a signer from the treasury
   pub struct RemoveSigner: MyMultiSig.Action {
     pub let signer: Address
     pub let intent: String
@@ -141,11 +248,13 @@ pub contract TreasuryActions {
 
       let manager = treasuryRef.borrowManager()
       manager.removeSigner(signer: self.signer)
+      emit RemoveSignerActionExecuted(address: self.signer, treasuryAddr: treasuryRef.owner!.address)
     }
 
     init(_signer: Address) {
       self.signer = _signer
       self.intent = "Remove ".concat((_signer as Address).toString()).concat(" as a signer to the Treasury.")
+      emit RemoveSignerActionCreated(address: _signer)
     }
   }
 
@@ -158,12 +267,15 @@ pub contract TreasuryActions {
       let treasuryRef: &DAOTreasury.Treasury = params["treasury"]! as! &DAOTreasury.Treasury
 
       let manager = treasuryRef.borrowManager()
+      let oldThreshold = manager.threshold
       manager.updateThreshold(newThreshold: self.threshold)
+      emit UpdateThresholdActionExecuted(oldThreshold: oldThreshold, newThreshold: self.threshold, treasuryAddr: treasuryRef.owner!.address)
     }
 
     init(_threshold: UInt64) {
       self.threshold = _threshold
       self.intent = "Update the threshold of signers needed to execute an action in the Treasury."
+      emit UpdateThresholdActionCreated(threshold: _threshold)
     }
   }
 }


### PR DESCRIPTION
* Adds events to `DAOTreasury.cdc`
* Adds events to `MyMultiSig.cdc`
* Adds events to `TreasuryActions.cdc`

Some of these events are a little redundant, because I wasn't 100% sure which events would be the most useful.

Some of these events also might not contain all the context the front-end needs to query them properly.  We will need to play around with the Events API to determine whether we need to enrich any of these events further to serve the FE needs.