### PR TITLE
VSL-43: Add Events to VESSEL Contracts

### DIFF
--- a/contracts/DAOTreasury.cdc
+++ b/contracts/DAOTreasury.cdc
@@ -7,6 +7,17 @@ pub contract DAOTreasury {
   pub let TreasuryStoragePath: StoragePath
   pub let TreasuryPublicPath: PublicPath
 
+  // Events
+  pub event TreasuryInitialized(initialSigners: [Address], initialThreshold: UInt64)
+  pub event ProposeAction(actionUUID: UInt64)
+  pub event ExecuteAction(actionUUID: UInt64)
+  pub event DepositVault(vaultID: String)
+  pub event DepositCollection(collectionID: String)
+  pub event WithdrawTokens(vaultID: String, amount: UFix64)
+  pub event WithdrawNFT(collectionID: String, nftID: UInt64)
+
+
+  // Interfaces + Resources
   pub resource interface TreasuryPublic {
     pub fun proposeAction(action: {MyMultiSig.Action}): UInt64
     pub fun executeAction(actionUUID: UInt64)
@@ -48,6 +59,7 @@ pub contract DAOTreasury {
     pub fun executeAction(actionUUID: UInt64) {
       let selfRef: &Treasury = &self as &Treasury
       self.multiSignManager.executeAction(actionUUID: actionUUID, {"treasury": selfRef})
+      emit ExecuteAction(actionUUID: actionUUID)
     }
 
     // Reference to Manager //
@@ -69,10 +81,12 @@ pub contract DAOTreasury {
       } else {
         self.vaults[identifier] <-! vault
       }
+      emit DepositVault(vaultID: identifier)
     }
 
     // Withdraw some tokens //
     pub fun withdrawTokens(identifier: String, amount: UFix64): @FungibleToken.Vault {
+      emit WithdrawTokens(vaultID: identifier, amount: amount)
       let vaultRef = (&self.vaults[identifier] as &FungibleToken.Vault?)!
       return <- vaultRef.withdraw(amount: amount)
     }
@@ -96,11 +110,14 @@ pub contract DAOTreasury {
 
     // Deposit a Collection //
     pub fun depositCollection(collection: @NonFungibleToken.Collection) {
-      self.collections[collection.getType().identifier] <-! collection
+      let identifier = collection.getType().identifier
+      self.collections[identifier] <-! collection
+      emit DepositCollection(collectionID: identifier)
     }
 
     // Withdraw an NFT //
     pub fun withdrawNFT(identifier: String, id: UInt64): @NonFungibleToken.NFT {
+      emit WithdrawNFT(collectionID: identifier, nftID: id)
       let collectionRef = (&self.collections[identifier] as &NonFungibleToken.Collection?)!
       return <- collectionRef.withdraw(withdrawID: id)
     }

--- a/contracts/TreasuryActions.cdc
+++ b/contracts/TreasuryActions.cdc
@@ -5,6 +5,54 @@ import NonFungibleToken from "./core/NonFungibleToken.cdc"
 
 pub contract TreasuryActions {
 
+  ///////////
+  // Events
+  ///////////
+
+  // TransferToken
+  pub event TransferTokenToAccountActionCreated(
+    recipientAddr: Address, vaultID: String, amount: UFix64
+  )
+  pub event TransferTokenToAccountActionExecuted(
+    recipientAddr: Address, vaultID: String, amount: UFix64, treasuryAddr: Address
+  )
+
+  // TransferTokenToTreasury
+  pub event TransferTokenToTreasuryActionCreated(
+    recipientAddr: Address, vaultID: String, amount: UFix64
+  )
+  pub event TransferTokenToTreasuryActionExecuted(
+    recipientAddr: Address, vaultID: String, amount: UFix64, treasuryAddr: Address
+  )
+
+  // TransferNFT
+  pub event TransferNFTToAccountActionCreated(
+    recipientAddr: Address, collectionID: String, nftID: UInt64
+  )
+  pub event TransferNFTToAccountActionExecuted(
+    recipientAddr: Address, collectionID: String, nftID: UInt64, treasuryAddr: Address
+  )
+
+  // TransferNFTToTreasury
+  pub event TransferNFTToTreasuryActionCreated(
+    recipientAddr: Address, collectionID: String, nftID: UInt64
+  )
+  pub event TransferNFTToTreasuryActionExecuted(
+    recipientAddr: Address, collectionID: String, nftID: UInt64, treasuryAddr: Address
+  )
+
+  // Add Signer
+  pub event AddSignerActionCreated(address: Address)
+  pub event AddSignerActionExecuted(address: Address, treasuryAddr: Address)
+  
+  // Remove Signer
+  pub event RemoveSignerActionCreated(address: Address)
+  pub event RemoveSignerActionExecuted(address: Address, treasuryAddr: Address)
+
+  // Update Threshold
+  pub event UpdateThresholdActionCreated(threshold: UInt64)
+  pub event UpdateThresholdActionExecuted(oldThreshold: UInt64, newThreshold: UInt64, treasuryAddr: Address)
+
   // Transfers `amount` tokens from the treasury to `recipientVault`
   pub struct TransferToken: MyMultiSig.Action {
     pub let intent: String
@@ -13,10 +61,16 @@ pub contract TreasuryActions {
 
     pub fun execute(_ params: {String: AnyStruct}) {
       let treasuryRef: &DAOTreasury.Treasury = params["treasury"]! as! &DAOTreasury.Treasury
-
       let vaultRef: &FungibleToken.Vault = treasuryRef.borrowVault(identifier: self.recipientVault.borrow()!.getType().identifier)
       let withdrawnTokens <- vaultRef.withdraw(amount: self.amount)
       self.recipientVault.borrow()!.deposit(from: <- withdrawnTokens)
+
+      emit TransferTokenToAccountActionExecuted(
+        recipientAddr: self.recipientVault.borrow()!.owner!.address,
+        vaultID: self.recipientVault.getType().identifier,
+        amount: self.amount,
+        treasuryAddr: treasuryRef.owner!.address
+      )
     }
 
     init(_recipientVault: Capability<&{FungibleToken.Receiver}>, _amount: UFix64) {
@@ -28,6 +82,12 @@ pub contract TreasuryActions {
                         .concat(_recipientVault.borrow()!.owner!.address.toString())
       self.recipientVault = _recipientVault
       self.amount = _amount
+
+      emit TransferTokenToAccountActionCreated(
+        recipientAddr: _recipientVault.borrow()!.owner!.address,
+        vaultID: _recipientVault.getType().identifier,
+        amount: _amount
+      )
     }
   }
 
@@ -42,19 +102,34 @@ pub contract TreasuryActions {
       let treasuryRef: &DAOTreasury.Treasury = params["treasury"]! as! &DAOTreasury.Treasury
       let vaultRef: &FungibleToken.Vault = treasuryRef.borrowVault(identifier: self.identifier)
       let withdrawnTokens <- vaultRef.withdraw(amount: self.amount)
+      let recipientAddr = self.recipientTreasury.borrow()!.owner!.address
       self.recipientTreasury.borrow()!.depositVault(vault: <- withdrawnTokens)
+
+      emit TransferTokenToTreasuryActionExecuted(
+        recipientAddr: recipientAddr,
+        vaultID: self.identifier,
+        amount: self.amount,
+        treasuryAddr: treasuryRef.owner!.address
+      )
     }
 
     init(_recipientTreasury: Capability<&{DAOTreasury.TreasuryPublic}>, _identifier: String, _amount: UFix64) {
+      let recipientAddr = _recipientTreasury.borrow()!.owner!.address
       self.intent = "Transfer "
                         .concat(_amount.toString())
                         .concat(" ")
                         .concat(_identifier)
                         .concat(" tokens from the treasury to ")
-                        .concat(_recipientTreasury.borrow()!.owner!.address.toString())
+                        .concat(recipientAddr.toString())
       self.identifier = _identifier
       self.recipientTreasury = _recipientTreasury
       self.amount = _amount
+
+      emit TransferTokenToTreasuryActionCreated(
+        recipientAddr: recipientAddr,
+        vaultID: _identifier,
+        amount: _amount
+      )
     }
   }
 
@@ -66,19 +141,34 @@ pub contract TreasuryActions {
 
     pub fun execute(_ params: {String: AnyStruct}) {
       let treasuryRef: &DAOTreasury.Treasury = params["treasury"]! as! &DAOTreasury.Treasury
-
-      let collectionRef: &NonFungibleToken.Collection = treasuryRef.borrowCollection(identifier: self.recipientCollection.borrow()!.getType().identifier)
+      let collectionID = self.recipientCollection.borrow()!.getType().identifier
+      let collectionRef: &NonFungibleToken.Collection = treasuryRef.borrowCollection(identifier: collectionID)
       let nft <- collectionRef.withdraw(withdrawID: self.withdrawID)
       self.recipientCollection.borrow()!.deposit(token: <- nft)
+
+      emit TransferNFTToAccountActionExecuted(
+        recipientAddr: self.recipientCollection.borrow()!.owner!.address,
+        collectionID: collectionID,
+        nftID: self.withdrawID,
+        treasuryAddr: treasuryRef.owner!.address
+      )
     }
 
     init(_recipientCollection: Capability<&{NonFungibleToken.CollectionPublic}>, _nftID: UInt64) {
+      let recipientAddr = _recipientCollection.borrow()!.owner!.address
+      let collectionID = _recipientCollection.getType().identifier
+
       self.intent = "Transfer a "
-                        .concat(_recipientCollection.getType().identifier)
+                        .concat(collectionID)
                         .concat(" NFT from the treasury to ")
-                        .concat(_recipientCollection.borrow()!.uuid.toString())
+                        .concat(recipientAddr.toString())
       self.recipientCollection = _recipientCollection
       self.withdrawID = _nftID
+      emit TransferNFTToAccountActionCreated(
+        recipientAddr: recipientAddr,
+        collectionID: collectionID,
+        nftID: _nftID
+      )
     }
   }
 
@@ -96,9 +186,17 @@ pub contract TreasuryActions {
 
       let recipientCollectionRef: &{NonFungibleToken.CollectionPublic} = self.recipientTreasury.borrow()!.borrowCollectionPublic(identifier: self.identifier)
       recipientCollectionRef.deposit(token: <- nft)
+
+      emit TransferNFTToTreasuryActionExecuted(
+        recipientAddr: self.recipientTreasury.borrow()!.owner!.address,
+        collectionID: self.identifier,
+        nftID: self.withdrawID,
+        treasuryAddr: treasuryRef.owner!.address
+      )
     }
 
     init(_recipientTreasury: Capability<&{DAOTreasury.TreasuryPublic}>, _identifier: String, _nftID: UInt64) {
+      let recipientAddr = _recipientTreasury.borrow()!.owner!.address
       self.intent = "Transfer an NFT from collection"
                         .concat(" ")
                         .concat(_identifier)
@@ -106,10 +204,16 @@ pub contract TreasuryActions {
                         .concat(_nftID.toString())
                         .concat(" ")
                         .concat(" from this Treasury to Treasury at address ")
-                        .concat(_recipientTreasury.borrow()!.owner!.address.toString())
+                        .concat(recipientAddr.toString())
       self.identifier = _identifier
       self.recipientTreasury = _recipientTreasury
       self.withdrawID= _nftID
+
+      emit TransferNFTToTreasuryActionCreated(
+        recipientAddr: recipientAddr,
+        collectionID: _identifier,
+        nftID: _nftID
+      )
     }
   }
 
@@ -123,15 +227,18 @@ pub contract TreasuryActions {
 
       let manager = treasuryRef.borrowManager()
       manager.addSigner(signer: self.signer)
+
+      emit AddSignerActionExecuted(address: self.signer, treasuryAddr: treasuryRef.owner!.address)
     }
 
     init(_signer: Address) {
       self.signer = _signer
       self.intent = "Add a signer to the Treasury."
+      emit AddSignerActionCreated(address: _signer)
     }
   }
 
-    // Remove a signer from the treasury
+  // Remove a signer from the treasury
   pub struct RemoveSigner: MyMultiSig.Action {
     pub let signer: Address
     pub let intent: String
@@ -141,11 +248,13 @@ pub contract TreasuryActions {
 
       let manager = treasuryRef.borrowManager()
       manager.removeSigner(signer: self.signer)
+      emit RemoveSignerActionExecuted(address: self.signer, treasuryAddr: treasuryRef.owner!.address)
     }
 
     init(_signer: Address) {
       self.signer = _signer
       self.intent = "Remove ".concat((_signer as Address).toString()).concat(" as a signer to the Treasury.")
+      emit RemoveSignerActionCreated(address: _signer)
     }
   }
 
@@ -158,12 +267,15 @@ pub contract TreasuryActions {
       let treasuryRef: &DAOTreasury.Treasury = params["treasury"]! as! &DAOTreasury.Treasury
 
       let manager = treasuryRef.borrowManager()
+      let oldThreshold = manager.threshold
       manager.updateThreshold(newThreshold: self.threshold)
+      emit UpdateThresholdActionExecuted(oldThreshold: oldThreshold, newThreshold: self.threshold, treasuryAddr: treasuryRef.owner!.address)
     }
 
     init(_threshold: UInt64) {
       self.threshold = _threshold
       self.intent = "Update the threshold of signers needed to execute an action in the Treasury."
+      emit UpdateThresholdActionCreated(threshold: _threshold)
     }
   }
 }

--- a/flow.json
+++ b/flow.json
@@ -71,20 +71,84 @@
 			"address": "179b6b1cb6755e31",
 			"key": "64e847c1c615c0d6e928f80c641a5974ead26293ac2a8623d6756c935be13630"
 		},
-		"emulator-signer2": {
+		"emulator-signer10": {
 			"address": "f3fcd2c1a78f5eee",
 			"key": "d774eb699bc67d07c8be7cbcee1acfa14e5139ac271ca697b25a081a19335efd"
 		},
-		"emulator-signer3": {
+		"emulator-signer11": {
 			"address": "e03daebed8ca0615",
 			"key": "843d964aefbc2b6311363551187b8241466ec02e8bc4ba5e000a8b2c02fca69f"
 		},
-		"emulator-signer4": {
+		"emulator-signer12": {
 			"address": "045a1763c93006ca",
 			"key": "843d964aefbc2b6311363551187b8241466ec02e8bc4ba5e000a8b2c02fca69f"
 		},
-		"emulator-treasuryOwner": {
+		"emulator-signer13": {
 			"address": "120e725050340cab",
+			"key": "a2b8847de0dcc39cbd901f2e394c902d4a27d112371ff8c75a5eea3720820bdc"
+		},
+		"emulator-signer14": {
+			"address": "f669cb8d41ce0c74",
+			"key": "1e246590ad418659391b226d5cf1afb4f67002d2617c0b00861ef52bafc75544"
+		},
+		"emulator-signer15": {
+			"address": "192440c99cb17282",
+			"key": "0a5d94786a895a2fdd5614d4c4227d1893c6695fd348836b4f4c65e6b5e12de0"
+		},
+		"emulator-signer16": {
+			"address": "fd43f9148d4b725d",
+			"key": "09b776b276d1cb6abde1e2aa0530a67d32a156dfbd95afa528469296336e1283"
+		},
+		"emulator-signer17": {
+			"address": "eb179c27144f783c",
+			"key": "985c3d13e7bc5f2925317c0cc139f9bb51e66d0b67be5fc1a885428948554b51"
+		},
+		"emulator-signer18": {
+			"address": "0f7025fa05b578e3",
+			"key": "985c3d13e7bc5f2925317c0cc139f9bb51e66d0b67be5fc1a885428948554b51"
+		},
+		"emulator-signer19": {
+			"address": "e2f72218abeec2b9",
+			"key": "985c3d13e7bc5f2925317c0cc139f9bb51e66d0b67be5fc1a885428948554b51"
+		},
+		"emulator-signer2": {
+			"address": "06909bc5ba14c266",
+			"key": "985c3d13e7bc5f2925317c0cc139f9bb51e66d0b67be5fc1a885428948554b51"
+		},
+		"emulator-signer20": {
+			"address": "10c4fef62310c807",
+			"key": "985c3d13e7bc5f2925317c0cc139f9bb51e66d0b67be5fc1a885428948554b51"
+		},
+		"emulator-signer3": {
+			"address": "f4a3472b32eac8d8",
+			"key": "985c3d13e7bc5f2925317c0cc139f9bb51e66d0b67be5fc1a885428948554b51"
+		},
+		"emulator-signer4": {
+			"address": "1beecc6fef95b62e",
+			"key": "985c3d13e7bc5f2925317c0cc139f9bb51e66d0b67be5fc1a885428948554b51"
+		},
+		"emulator-signer5": {
+			"address": "ff8975b2fe6fb6f1",
+			"key": "985c3d13e7bc5f2925317c0cc139f9bb51e66d0b67be5fc1a885428948554b51"
+		},
+		"emulator-signer6": {
+			"address": "e9dd1081676bbc90",
+			"key": "985c3d13e7bc5f2925317c0cc139f9bb51e66d0b67be5fc1a885428948554b51"
+		},
+		"emulator-signer7": {
+			"address": "0dbaa95c7691bc4f",
+			"key": "985c3d13e7bc5f2925317c0cc139f9bb51e66d0b67be5fc1a885428948554b51"
+		},
+		"emulator-signer8": {
+			"address": "1e7bd52309d4e4b4",
+			"key": "985c3d13e7bc5f2925317c0cc139f9bb51e66d0b67be5fc1a885428948554b51"
+		},
+		"emulator-signer9": {
+			"address": "fa1c6cfe182ee46b",
+			"key": "985c3d13e7bc5f2925317c0cc139f9bb51e66d0b67be5fc1a885428948554b51"
+		},
+		"emulator-treasuryOwner": {
+			"address": "ec4809cd812aee0a",
 			"key": "843d964aefbc2b6311363551187b8241466ec02e8bc4ba5e000a8b2c02fca69f"
 		},
 		"testnet-account": {
@@ -113,6 +177,23 @@
 			"emulator-signer2": [],
 			"emulator-signer3": [],
 			"emulator-signer4": [],
+			"emulator-signer5": [],
+			"emulator-signer6": [],
+			"emulator-signer7": [],
+			"emulator-signer8": [],
+			"emulator-signer9": [],
+			"emulator-signer10": [],
+			"emulator-signer11": [],
+			"emulator-signer12": [],
+			"emulator-signer13": [],
+			"emulator-signer14": [],
+			"emulator-signer15": [],
+			"emulator-signer16": [],
+			"emulator-signer17": [],
+			"emulator-signer18": [],
+			"emulator-signer19": [],
+			"emulator-signer20": [],
+
 			"emulator-treasuryOwner": []
 		},
 		"testnet": {

--- a/generate_accounts.zsh
+++ b/generate_accounts.zsh
@@ -1,0 +1,19 @@
+#!/bin/zsh
+
+# flow init --reset --service-private-key f8e188e8af0b8b414be59c4a1a15cc666c898fb34d94156e9b51e18bfde754a5
+
+for i in {1..30}
+do
+    # Generate Private Key
+    PRIVATEKEY=$(flow keys generate | grep '^Private Key \(.*\)' | tail -c 66 | grep '.*')
+    PUBLICKEY=$(flow keys generate | grep '^Public Key \(.*\)' | tail -c 130 | grep '.*')
+    echo "Private Key:\n$PRIVATEKEY"
+    echo "Public  Key:\n$PUBLICKEY"
+    # Create Account
+    ADDR=$(echo $PUBLICKEY | xargs flow accounts create --key | grep Address | tail -c 19 | grep ".*")
+    echo "Address: $ADDR\n"
+    TIME=1
+    # (echo "emulator-signer$i"; sleep $TIME; echo $ADDR; sleep $TIME; echo; sleep $TIME; echo; sleep $TIME; echo $PRIVATEKEY | xargs; sleep $TIME; echo 0; sleep $TIME) | flow config add account
+    # echo "emulator-signer$i"; sleep $TIME; echo $ADDR; sleep $TIME; echo; sleep $TIME; echo; sleep $TIME; echo $PRIVATEKEY;
+
+done

--- a/main_test.go
+++ b/main_test.go
@@ -208,6 +208,10 @@ func TestTransferFungibleTokensToTreasuryActions(t *testing.T) {
 	})
 }
 
+func TestTransferNonFungibleTokensToAccountActions(t *testing.T) {
+	// TODO
+}
+
 func TestTransferNonFungibleTokensToTreasuryActions(t *testing.T) {
 	var transferNFTActionUUID uint64
 

--- a/main_test.go
+++ b/main_test.go
@@ -11,7 +11,8 @@ var NonFungibleTokenCollectionID = "A.f8d6e0586b0a20c7.ExampleNFT.Collection"
 var DefaultAccountBalance uint64 = 1e5
 var TransferAmount float64 = 100
 var TransferAmountUInt64 uint64 = 100e8
-var Signers = []string{"signer1", "signer2", "signer3", "signer4"}
+var Signers = []string{"signer1", "signer2", "signer3", "signer4", "signer5"}
+var DefaultThreshold = len(Signers)
 var RecipientAcct = "recipient"
 
 func TestTreasurySetup(t *testing.T) {
@@ -19,7 +20,7 @@ func TestTreasurySetup(t *testing.T) {
 	otu.MintFlow("signer1", TransferAmount)
 
 	t.Run("User should be able to add a Treasury to their account.", func(t *testing.T) {
-		otu.SetupTreasury("treasuryOwner", Signers)
+		otu.SetupTreasury("treasuryOwner", Signers, uint64(DefaultThreshold))
 	})
 
 	t.Run("Signing account should have been initialized with specified signers.", func(t *testing.T) {
@@ -63,7 +64,7 @@ func TestTransferTokensToAccountActions(t *testing.T) {
 
 	otu := NewOverflowTest(t)
 	otu.MintFlow("signer1", TransferAmount)
-	otu.SetupTreasury("treasuryOwner", Signers)
+	otu.SetupTreasury("treasuryOwner", Signers, uint64(DefaultThreshold))
 	otu.SendFlowToTreasury("signer1", "treasuryOwner", TransferAmount)
 	otu.CreateNFTCollection("account")
 	otu.MintNFT("account")
@@ -155,7 +156,7 @@ func TestTransferFungibleTokensToTreasuryActions(t *testing.T) {
 
 	otu := NewOverflowTest(t)
 	otu.MintFlow("signer1", TransferAmount)
-	otu.SetupTreasury("treasuryOwner", Signers)
+	otu.SetupTreasury("treasuryOwner", Signers, uint64(DefaultThreshold))
 	otu.SendFlowToTreasury("signer1", "treasuryOwner", TransferAmount)
 	otu.CreateNFTCollection("account")
 	otu.MintNFT("account")
@@ -166,7 +167,7 @@ func TestTransferFungibleTokensToTreasuryActions(t *testing.T) {
 	otu.SendNFTToTreasury("account", "treasuryOwner", 0)
 
 	// Recipient treasury
-	otu.SetupTreasury("recipient", Signers)
+	otu.SetupTreasury("recipient", Signers, uint64(DefaultThreshold))
 
 	t.Run("Signers should be able to propose a transfer of fungible tokens out of the Treasury to another Treasury", func(t *testing.T) {
 		otu.ProposeFungibleTokenTransferToTreasuryAction("treasuryOwner", Signers[0], RecipientAcct, FlowTokenVaultID, TransferAmount)
@@ -211,7 +212,7 @@ func TestTransferNonFungibleTokensToTreasuryActions(t *testing.T) {
 	var transferNFTActionUUID uint64
 
 	otu := NewOverflowTest(t)
-	otu.SetupTreasury("treasuryOwner", Signers)
+	otu.SetupTreasury("treasuryOwner", Signers, uint64(DefaultThreshold))
 	otu.CreateNFTCollection("account")
 	otu.MintNFT("account")
 
@@ -220,7 +221,7 @@ func TestTransferNonFungibleTokensToTreasuryActions(t *testing.T) {
 	otu.SendNFTToTreasury("account", "treasuryOwner", 0)
 
 	// Recipient treasury
-	otu.SetupTreasury("recipient", Signers)
+	otu.SetupTreasury("recipient", Signers, uint64(DefaultThreshold))
 
 	t.Run("Signers should be able to propose a transfer of a non fungible token out of the Treasury to another Treasury", func(t *testing.T) {
 		otu.ProposeNonFungibleTokenTransferToTreasuryAction("treasuryOwner", Signers[0], RecipientAcct, NonFungibleTokenCollectionID, 0)

--- a/test_utils.go
+++ b/test_utils.go
@@ -25,7 +25,7 @@ func NewOverflowTest(t *testing.T) *OverflowTestUtils {
 	// return &OverflowTestUtils{T: t, O: overflow.NewOverflowEmulator().Start()}
 }
 
-func (otu *OverflowTestUtils) SetupTreasury(name string, signers []string) *OverflowTestUtils {
+func (otu *OverflowTestUtils) SetupTreasury(name string, signers []string, threshold uint64) *OverflowTestUtils {
 	addresses := make([]string, len(signers))
 	for _, name := range signers {
 		addresses = append(addresses, otu.GetAccountAddress(name))
@@ -36,7 +36,7 @@ func (otu *OverflowTestUtils) SetupTreasury(name string, signers []string) *Over
 		Args(otu.O.Arguments().
 			RawAddressArray(
 				addresses...).
-			UInt64(2)).
+			UInt64(threshold)).
 		Test(otu.T).
 		AssertSuccess()
 


### PR DESCRIPTION
* Adds events to `DAOTreasury.cdc`
* Adds events to `MyMultiSig.cdc`
* Adds events to `TreasuryActions.cdc`

NOTE:

Some of these events are a little redundant, because I wasn't 100% sure which events would be the most useful.

Some of these events also might not contain all the context the front-end needs to query them properly. We will need to play around with the Events API to determine whether we need to enrich any of these events further to serve the FE needs.