### PR TITLE
VSL-26: Added test case with 20 signers

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -12,7 +12,9 @@ var DefaultAccountBalance uint64 = 1e5
 var TransferAmount float64 = 100
 var TransferAmountUInt64 uint64 = 100e8
 var Signers = []string{"signer1", "signer2", "signer3", "signer4", "signer5"}
+var MaxSigners = GenerateSigners(20)
 var DefaultThreshold = len(Signers)
+var MaxThreshold = 20
 var RecipientAcct = "recipient"
 
 func TestTreasurySetup(t *testing.T) {
@@ -24,8 +26,11 @@ func TestTreasurySetup(t *testing.T) {
 	})
 
 	t.Run("Signing account should have been initialized with specified signers.", func(t *testing.T) {
-		// signers := otu.GetTreasurySigners("treasuryOwner")
-		// TODO: Verify addresses are there
+		signers := otu.GetTreasurySigners("treasuryOwner").String()
+
+		for _, signer := range Signers {
+			assert.Contains(otu.T, signers, otu.GetAccountAddress(signer))
+		}
 	})
 
 	t.Run("Treasury should be able to receive fungible tokens", func(t *testing.T) {
@@ -133,6 +138,98 @@ func TestTransferTokensToAccountActions(t *testing.T) {
 		// Assert that the signatures were registered
 		signersMap := otu.GetVerifiedSignersForAction("treasuryOwner", transferNFTActionUUID)
 		for _, signer := range Signers {
+			assert.True(otu.T, true, signersMap[otu.GetAccountAddress(signer)])
+		}
+	})
+
+	t.Run(`A signer should be able to execute a proposed action to transfer an NFT once it has received
+		the required threshold of signatures`, func(t *testing.T) {
+		otu.ExecuteAction("treasuryOwner", transferNFTActionUUID)
+
+		// Assert that the NFT has been transfered out of the treasury vault
+		collectionIds := otu.GetTreasuryIdentifiers("treasuryOwner")
+		ownedNFTIds := otu.GetTreasuryCollection("treasuryOwner", collectionIds[1][0])
+		assert.Equal(otu.T, 0, len(ownedNFTIds))
+
+		// TODO: Assert that the NFT has been received by the recipient account
+	})
+}
+
+func TestTransferTokensToAccountActionsWith20Signers(t *testing.T) {
+	var transferTokenActionUUID uint64
+	var transferNFTActionUUID uint64
+
+	otu := NewOverflowTest(t)
+	otu.MintFlow("signer1", TransferAmount)
+	otu.SetupTreasury("treasuryOwner", MaxSigners, uint64(MaxThreshold))
+	otu.SendFlowToTreasury("signer1", "treasuryOwner", TransferAmount)
+	otu.CreateNFTCollection("account")
+	otu.MintNFT("account")
+
+	otu.CreateNFTCollection("treasuryOwner")
+	otu.SendCollectionToTreasury("treasuryOwner", "treasuryOwner")
+	otu.SendNFTToTreasury("account", "treasuryOwner", 0)
+
+	t.Run("Signers should be able to propose a transfer of fungible tokens out of the Treasury", func(t *testing.T) {
+		otu.ProposeFungibleTokenTransferAction("treasuryOwner", MaxSigners[0], RecipientAcct, TransferAmount)
+	})
+
+	t.Run("Signers should be able to sign to approve a proposed action to transfer tokens", func(t *testing.T) {
+		// Get first ID of proposed action
+		actions := otu.GetProposedActions("treasuryOwner")
+		keys := make([]uint64, 0, len(actions))
+		for k := range actions {
+			keys = append(keys, k)
+		}
+		transferTokenActionUUID = keys[0]
+
+		// Each signer submits an approval signature
+		for _, signer := range MaxSigners {
+			otu.SignerApproveAction("treasuryOwner", transferTokenActionUUID, signer)
+		}
+
+		// Assert that the signatures were registered
+		signersMap := otu.GetVerifiedSignersForAction("treasuryOwner", transferTokenActionUUID)
+		for _, signer := range MaxSigners {
+			assert.True(otu.T, true, signersMap[otu.GetAccountAddress(signer)])
+		}
+	})
+
+	t.Run(`A signer should be able to execute a proposed action to transfer tokens once it has received
+		the required threshold of signatures`, func(t *testing.T) {
+		otu.ExecuteAction("treasuryOwner", transferTokenActionUUID)
+
+		// Assert that all funds have been transfered out of the treasury vault
+		treasuryBalance := otu.GetTreasuryVaultBalance("treasuryOwner", FlowTokenVaultID)
+		assert.Equal(otu.T, uint64(0), treasuryBalance)
+
+		// Assert that all funds have been received by the recipient account
+		recipientBalance := otu.GetAccount(RecipientAcct).Balance
+		assert.Equal(otu.T, TransferAmountUInt64+DefaultAccountBalance, recipientBalance)
+	})
+
+	t.Run("Signers should be able to propose a transfer of a non-fungible token out of the Treasury", func(t *testing.T) {
+		// TODO: create collection in one of the signer accounts
+		otu.ProposeNonFungibleTokenTransferAction("treasuryOwner", MaxSigners[0], "account", uint64(0))
+	})
+
+	t.Run("Signers should be able to sign to approve a proposed action to transfer an NFT", func(t *testing.T) {
+		// Get first ID of proposed action
+		actions := otu.GetProposedActions("treasuryOwner")
+		keys := make([]uint64, 0, len(actions))
+		for k := range actions {
+			keys = append(keys, k)
+		}
+		transferNFTActionUUID = keys[0]
+
+		// Each signer submits an approval signature
+		for _, signer := range MaxSigners {
+			otu.SignerApproveAction("treasuryOwner", transferNFTActionUUID, signer)
+		}
+
+		// Assert that the signatures were registered
+		signersMap := otu.GetVerifiedSignersForAction("treasuryOwner", transferNFTActionUUID)
+		for _, signer := range MaxSigners {
 			assert.True(otu.T, true, signersMap[otu.GetAccountAddress(signer)])
 		}
 	})

--- a/test_utils.go
+++ b/test_utils.go
@@ -147,6 +147,14 @@ func (otu *OverflowTestUtils) GetProposedActions(treasuryAcct string) map[uint64
 	return actionsMap
 }
 
+func GenerateSigners(num int) []string {
+	Signers := make([]string, num)
+	for i := 0; i < num; i++ {
+		Signers[i] = fmt.Sprintf("%s%d", "signer", i+1)
+	}
+	return Signers
+}
+
 func (otu *OverflowTestUtils) GetTreasurySigners(account string) cadence.Value {
 	signers := otu.O.ScriptFromFile("get_treasury_signers").
 		Args(otu.O.Arguments().Account(account)).


### PR DESCRIPTION
Based on branch jackson/VSL-43-events

Added util function that creates an array of signers
Added verification for signers in TestTreasurySetup
Added TestTransferTokensToAccountActionsWith20Signers which has the same flow as TestTransferTokensToAccountActions but has 20 signers