### PR TITLE
VSL-27: Added tests for rejected transactions without required signers

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -88,6 +88,8 @@ func TestTransferTokensToAccountActions(t *testing.T) {
 
 		// Each signer submits an approval signature
 		for _, signer := range Signers {
+			// Test if the action fails without all signer approvals
+			otu.ExecuteActionFailed("treasuryOwner", transferTokenActionUUID, "This action has not received a signature from every signer yet.")
 			otu.SignerApproveAction("treasuryOwner", transferTokenActionUUID, signer)
 		}
 
@@ -127,6 +129,8 @@ func TestTransferTokensToAccountActions(t *testing.T) {
 
 		// Each signer submits an approval signature
 		for _, signer := range Signers {
+			// Test if the action fails without all signer approvals
+			otu.ExecuteActionFailed("treasuryOwner", transferNFTActionUUID, "This action has not received a signature from every signer yet.")
 			otu.SignerApproveAction("treasuryOwner", transferNFTActionUUID, signer)
 		}
 
@@ -184,6 +188,8 @@ func TestTransferFungibleTokensToTreasuryActions(t *testing.T) {
 
 		// Each signer submits an approval signature
 		for _, signer := range Signers {
+			// Test if the action fails without all signer approvals
+			otu.ExecuteActionFailed("treasuryOwner", transferTokenActionUUID, "This action has not received a signature from every signer yet.")
 			otu.SignerApproveAction("treasuryOwner", transferTokenActionUUID, signer)
 		}
 
@@ -242,6 +248,8 @@ func TestTransferNonFungibleTokensToTreasuryActions(t *testing.T) {
 
 		// Each signer submits an approval signature
 		for _, signer := range Signers {
+			// Test if the action fails without all signer approvals
+			otu.ExecuteActionFailed("treasuryOwner", transferNFTActionUUID, "This action has not received a signature from every signer yet.")
 			otu.SignerApproveAction("treasuryOwner", transferNFTActionUUID, signer)
 		}
 

--- a/test_utils.go
+++ b/test_utils.go
@@ -283,6 +283,18 @@ func (otu *OverflowTestUtils) MintFlow(account string, amount float64) *Overflow
 	return otu
 }
 
+func (otu *OverflowTestUtils) ExecuteActionFailed(treasuryAcct string, actionUUID uint64, msg string) *OverflowTestUtils {
+	otu.O.TransactionFromFile("execute_action").
+		SignProposeAndPayAs("signer1").
+		Args(otu.O.Arguments().
+			Account(treasuryAcct).
+			UInt64(actionUUID)).
+		Test(otu.T).
+		AssertFailure(msg)
+
+	return otu
+}
+
 func (otu *OverflowTestUtils) CreateNFTCollection(account string) *OverflowTestUtils {
 	otu.O.TransactionFromFile("create_collection").
 		SignProposeAndPayAs(account).


### PR DESCRIPTION
Based on jackson/VSL-43-events branch

- Added new util function for asserting failed actions ExecuteActionFailed which checks if the failure happened with the defined message
- Before every SignerApproveAction this function is called to check if the failure happens when insufficient number of signers approve the transaction
