### PR TITLE
Linxiao/vsl 48 adding test

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -209,7 +209,63 @@ func TestTransferFungibleTokensToTreasuryActions(t *testing.T) {
 }
 
 func TestTransferNonFungibleTokensToAccountActions(t *testing.T) {
-	// TODO
+	var transferNFTActionUUID uint64
+
+	otu := NewOverflowTest(t)
+	//create NFT collection and mint NFT for signer1
+	otu.CreateNFTCollection("signer1")
+	otu.MintNFT("signer1")
+
+	//set up treasury and send nft from signer1 to treasuray
+	otu.SetupTreasury("treasuryOwner", Signers, uint64(DefaultThreshold))
+	otu.CreateNFTCollection("treasuryOwner")
+	otu.SendCollectionToTreasury("treasuryOwner", "treasuryOwner")
+	otu.SendNFTToTreasury("signer1", "treasuryOwner", 0)
+
+	//set up the account
+	otu.CreateNFTCollection("account");
+
+
+	t.Run("Signers should be able to propose a transfer of non fungible tokens out of the Treasury", func(t *testing.T) {
+		otu.ProposeNonFungibleTokenTransferAction("treasuryOwner", Signers[0], "account", uint64(0))
+	})
+
+	t.Run("Signers should be able to sign to approve a proposed action to transfer a non-fungible token to an account", func(t *testing.T) {
+		// Get first ID of proposed action
+		actions := otu.GetProposedActions("treasuryOwner")
+		keys := make([]uint64, 0, len(actions))
+		for k := range actions {
+			keys = append(keys, k)
+		}
+		transferNFTActionUUID = keys[0]
+
+		// Each signer submits an approval signature
+		for _, signer := range Signers {
+			otu.SignerApproveAction("treasuryOwner", transferNFTActionUUID, signer)
+		}
+
+		// Assert that the signatures were registered
+		signersMap := otu.GetVerifiedSignersForAction("treasuryOwner", transferNFTActionUUID)
+		for _, signer := range Signers {
+			assert.True(otu.T, true, signersMap[otu.GetAccountAddress(signer)])
+		}
+	})
+
+	t.Run(`A signer should be able to execute a proposed action to transfer a non-fungible token to an account once it has received
+		the required threshold of signatures`, func(t *testing.T) {
+		otu.ExecuteAction("treasuryOwner", transferNFTActionUUID)
+
+		// Assert that the NFT has been transfered out of the treasury vault
+		collectionIds := otu.GetTreasuryIdentifiers("treasuryOwner")
+		ownedNFTIds := otu.GetTreasuryCollection("treasuryOwner", collectionIds[1][0])
+		assert.Equal(otu.T, 0, len(ownedNFTIds))
+
+		// Assert that the NFT has been transfered into the account collection
+		ownedNFTIds = otu.GetAccountCollection("account")
+		assert.Contains(otu.T, ownedNFTIds, uint64(0))
+	})
+
+
 }
 
 func TestTransferNonFungibleTokensToTreasuryActions(t *testing.T) {

--- a/scripts/get_account_collection.cdc
+++ b/scripts/get_account_collection.cdc
@@ -1,0 +1,9 @@
+import ExampleNFT from "../contracts/core/ExampleNFT.cdc"
+
+pub fun main(accountAddress: Address): [UInt64] {
+  let account = getAccount(accountAddress).getCapability(ExampleNFT.CollectionPublicPath)
+                    .borrow<&ExampleNFT.Collection{ExampleNFT.ExampleNFTCollectionPublic}>()
+                    ?? panic("A NFT collection doesn't exist here.")
+
+  return account.getIDs();
+}

--- a/test_utils.go
+++ b/test_utils.go
@@ -316,3 +316,14 @@ func (otu *OverflowTestUtils) GetAccount(name string) *flow.Account {
 
 	return account
 }
+func (otu *OverflowTestUtils) GetAccountCollection(account string) []uint64 {
+	val := otu.O.ScriptFromFile("get_account_collection").
+		Args(otu.O.Arguments().
+			Account(account)).
+		RunReturnsJsonString()
+
+	var ownedNFTIds []uint64
+	json.Unmarshal([]byte(val), &ownedNFTIds)
+
+	return ownedNFTIds
+}


### PR DESCRIPTION
added `TestTransferNonFungibleTokensToAccountActions` test block, including
- proposing an action that transfers NFT from treasury to account
- singers sign the action
- executing the action