### PR TITLE
VSL-60: QSP-7 Allow Signers to Revoke their Approval

### DIFF
--- a/contracts/DAOTreasury.cdc
+++ b/contracts/DAOTreasury.cdc
@@ -73,6 +73,8 @@ pub contract DAOTreasury {
 
     // ------- Vaults ------- 
 
+    // pub fun signerDepositVault(signerAddr: Address, message: String, keyIds: _keyIds)
+
     // Deposit a Vault //
     pub fun depositVault(vault: @FungibleToken.Vault) {
       let identifier = vault.getType().identifier

--- a/contracts/DAOTreasury.cdc
+++ b/contracts/DAOTreasury.cdc
@@ -73,8 +73,6 @@ pub contract DAOTreasury {
 
     // ------- Vaults ------- 
 
-    // pub fun signerDepositVault(signerAddr: Address, message: String, keyIds: _keyIds)
-
     // Deposit a Vault //
     pub fun depositVault(vault: @FungibleToken.Vault) {
       let identifier = vault.getType().identifier

--- a/contracts/MyMultiSig.cdc
+++ b/contracts/MyMultiSig.cdc
@@ -68,7 +68,7 @@ pub contract MyMultiSig {
     pub resource MultiSignAction {
 
         pub var totalVerified: UInt64
-        access(account) var accountsVerified: {Address: Bool}
+        pub var accountsVerified: {Address: Bool}
         access(contract) let action: {Action}
 
         // ZayVerifierv2 - verifySignature

--- a/scripts/get_total_verified_for_action.cdc
+++ b/scripts/get_total_verified_for_action.cdc
@@ -1,0 +1,9 @@
+import DAOTreasury from "../contracts/DAOTreasury.cdc"
+
+pub fun main(treasuryAddr: Address, actionUUID: UInt64): UInt64 {
+  let treasury = getAccount(treasuryAddr).getCapability(DAOTreasury.TreasuryPublicPath)
+                    .borrow<&DAOTreasury.Treasury{DAOTreasury.TreasuryPublic}>()
+                    ?? panic("A DAOTreasury doesn't exist here.")
+
+  return treasury.borrowManagerPublic().getTotalVerifiedForAction(actionUUID: actionUUID)
+}

--- a/transactions/signer_approve.cdc
+++ b/transactions/signer_approve.cdc
@@ -2,10 +2,13 @@ import DAOTreasury from "../contracts/DAOTreasury.cdc"
 import MyMultiSig from "../contracts/MyMultiSig.cdc"
 
 transaction(treasuryAddr: Address, actionUUID: UInt64, message: String, keyIds: [UInt64], signatures: [String], signatureBlock: UInt64) {
+
+  var isValid: Bool
   let action: &MyMultiSig.MultiSignAction 
   let messageSignaturePayload: MyMultiSig.MessageSignaturePayload
 
   prepare(signer: AuthAccount) {
+    self.isValid = false
     let treasury = getAccount(treasuryAddr).getCapability(DAOTreasury.TreasuryPublicPath)
                     .borrow<&DAOTreasury.Treasury{DAOTreasury.TreasuryPublic}>()
                     ?? panic("A DAOTreasury doesn't exist here.")
@@ -15,10 +18,8 @@ transaction(treasuryAddr: Address, actionUUID: UInt64, message: String, keyIds: 
 
     var _keyIds: [Int] = []
 
-    var j = 0
     for keyId in keyIds {
       _keyIds.append(Int(keyId))
-      j = j + 1
     }
 
     self.messageSignaturePayload = MyMultiSig.MessageSignaturePayload(
@@ -27,6 +28,11 @@ transaction(treasuryAddr: Address, actionUUID: UInt64, message: String, keyIds: 
 
   }
   execute {
-    var isValid = self.action.signerApproveAction(_messageSignaturePayload: self.messageSignaturePayload)
+    self.isValid = self.action.signerApproveAction(_messageSignaturePayload: self.messageSignaturePayload)
+  }
+
+  post {
+    self.isValid == true: "Unable to revoke approval: invalid message or signature"
+    self.action.accountsVerified[self.messageSignaturePayload.signingAddr] == true: "Error: tx completed but signer approval not revoked"
   }
 }

--- a/transactions/signer_revoke.cdc
+++ b/transactions/signer_revoke.cdc
@@ -2,30 +2,37 @@ import DAOTreasury from "../contracts/DAOTreasury.cdc"
 import MyMultiSig from "../contracts/MyMultiSig.cdc"
 
 transaction(treasuryAddr: Address, actionUUID: UInt64, message: String, keyIds: [UInt64], signatures: [String], signatureBlock: UInt64) {
+
+  var isValid: Bool
+  var action: &MyMultiSig.MultiSignAction
+  var messageSignaturePayload: MyMultiSig.MessageSignaturePayload
   
   prepare(signer: AuthAccount) {
+    self.isValid = false
     let treasury = getAccount(treasuryAddr).getCapability(DAOTreasury.TreasuryPublicPath)
                     .borrow<&DAOTreasury.Treasury{DAOTreasury.TreasuryPublic}>()
                     ?? panic("A DAOTreasury doesn't exist here.")
 
     let manager = treasury.borrowManagerPublic()
-    let action = manager.borrowAction(actionUUID: actionUUID)
+    self.action = manager.borrowAction(actionUUID: actionUUID)
 
     var _keyIds: [Int] = []
 
-    var j = 0
     for keyId in keyIds {
       _keyIds.append(Int(keyId))
-      j = j + 1
     }
 
-    let messageSignaturePayload = MyMultiSig.MessageSignaturePayload(
+    self.messageSignaturePayload = MyMultiSig.MessageSignaturePayload(
       _signingAddr: signer.address, _message: message, _keyIds: _keyIds, _signatures: signatures, _signatureBlock: signatureBlock
     )
 
-    var isValid = action.signerRevokeApproval(_messageSignaturePayload: messageSignaturePayload)
   }
   execute {
-    
+    self.isValid = self.action.signerRevokeApproval(_messageSignaturePayload: self.messageSignaturePayload)
+  }
+
+  post {
+    self.isValid == true: "Unable to revoke approval: invalid message or signature"
+    self.action.accountsVerified[self.messageSignaturePayload.signingAddr] == false: "Error: tx completed but signer approval not revoked"
   }
 }

--- a/transactions/signer_revoke.cdc
+++ b/transactions/signer_revoke.cdc
@@ -2,16 +2,14 @@ import DAOTreasury from "../contracts/DAOTreasury.cdc"
 import MyMultiSig from "../contracts/MyMultiSig.cdc"
 
 transaction(treasuryAddr: Address, actionUUID: UInt64, message: String, keyIds: [UInt64], signatures: [String], signatureBlock: UInt64) {
-  let action: &MyMultiSig.MultiSignAction 
-  let messageSignaturePayload: MyMultiSig.MessageSignaturePayload
-
+  
   prepare(signer: AuthAccount) {
     let treasury = getAccount(treasuryAddr).getCapability(DAOTreasury.TreasuryPublicPath)
                     .borrow<&DAOTreasury.Treasury{DAOTreasury.TreasuryPublic}>()
                     ?? panic("A DAOTreasury doesn't exist here.")
 
     let manager = treasury.borrowManagerPublic()
-    self.action = manager.borrowAction(actionUUID: actionUUID)
+    let action = manager.borrowAction(actionUUID: actionUUID)
 
     var _keyIds: [Int] = []
 
@@ -21,12 +19,13 @@ transaction(treasuryAddr: Address, actionUUID: UInt64, message: String, keyIds: 
       j = j + 1
     }
 
-    self.messageSignaturePayload = MyMultiSig.MessageSignaturePayload(
+    let messageSignaturePayload = MyMultiSig.MessageSignaturePayload(
       _signingAddr: signer.address, _message: message, _keyIds: _keyIds, _signatures: signatures, _signatureBlock: signatureBlock
     )
 
+    var isValid = action.signerRevokeApproval(_messageSignaturePayload: messageSignaturePayload)
   }
   execute {
-    var isValid = self.action.signerApproveAction(_messageSignaturePayload: self.messageSignaturePayload)
+    
   }
 }


### PR DESCRIPTION
- adds `MultiSignAction.signerRevokeApproval` function for signers to revoke their approval of an action
- refactor `MultiSignAction.validateSignature` function to just generally validate whether a message signature is valid.  Validation of the message structure is now the responsibility of the functions that need to validate signatures (i.e. `signerApproveAction` and `signerRevokeApproval`)
- Updates tests + `signer_approve.cdc` tx to adhere to new payload that `signerApproveAction` expects
- Adds `TestSignerRevokeApproval` test