### PR TITLE
[DO NOT MERGE] VSL-73: Add Dapper Wallet as Authentication Option

### DIFF
--- a/packages/client/src/contexts/Web3.js
+++ b/packages/client/src/contexts/Web3.js
@@ -50,11 +50,20 @@ export default function Web3Provider({
   };
 
   useEffect(() => {
-    const { accessApi, walletDiscovery } = networks[network];
+    const { 
+      accessApi,
+      walletDiscovery,
+      walletDiscoveryApi,
+      walletDiscoveryInclude
+    } = networks[network];
+
     fcl
-      .config()
-      .put("accessNode.api", accessApi) // connect to Flow
-      .put("discovery.wallet", walletDiscovery); // use Blocto wallet
+      .config({
+        'accessNode.api': accessApi, // connect to Flow
+        'discovery.wallet': walletDiscovery, // use wallets on public discovery
+        'discovery.authn.endpoint': walletDiscoveryApi, // public discovery api endpoint
+        'discover.authn.include': walletDiscoveryInclude, // opt-in wallets
+      })
 
     try {
       const contracts = require("../contracts.json");

--- a/packages/client/src/networks.js
+++ b/packages/client/src/networks.js
@@ -2,14 +2,20 @@ const networksConfig = {
   emulator: {
     accessApi: "http://localhost:8888",
     walletDiscovery: "http://localhost:8701/fcl/authn",
+    walletDiscoveryApi: null,
+    walletDiscoveryInclude: [],
   },
   testnet: {
     accessApi: "https://rest-testnet.onflow.org",
     walletDiscovery: "https://fcl-discovery.onflow.org/testnet/authn",
+    walletDiscoveryApi: 'https://fcl-discovery.onflow.org/api/testnet/authn',
+    walletDiscoveryInclude: ['0x82ec283f88a62e65'],
   },
   mainnet: {
     accessApi: "https://access.onflow.org",
     walletDiscovery: "https://fcl-discovery.onflow.org/authn",
+    walletDiscoveryApi: 'https://fcl-discovery.onflow.org/api/authn',
+    walletDiscoveryInclude: ['0xead892083b3e2c6c'],
   },
 };
 


### PR DESCRIPTION
* Opt-in to Dapper Wallet via FCL config

NOTE: Do not merge until
- Dapper Wallet supports signed messages
- We have received clearance from compliance to integrate Dapper Wallet into VESSEL