### PR TITLE
fix number of signatures in UI

### DIFF
--- a/packages/client/src/components/ActionsList.js
+++ b/packages/client/src/components/ActionsList.js
@@ -49,7 +49,7 @@ function ActionsList({ actions = [], onSign, onConfirm, safeData }) {
             {actionPrompt}
           </div>
           <div className="pl-6" style={{ position: "relative" }}>
-            {totalSigned} of {totalSigs} signatures
+            {totalSigned} of {safeData.threshold} signatures
           </div>
           <div
             className="pl-6 is-underlined pointer"


### PR DESCRIPTION
**Issue**:
After adding a new owner, when threshold remains as 1, the signatures number under "Thing to do" become `0 of 2 signatures` as it's using the number of signers.

![Screen Shot 2022-07-19 at 9 27 51 PM](https://user-images.githubusercontent.com/105529038/180056328-17686a62-3da2-4d75-b414-3aec48212e17.png)

**Fix**:
The total number of signatures required should be the threshold number.

After fix:
![Screen Shot 2022-07-20 at 11 36 51 AM](https://user-images.githubusercontent.com/105529038/180057330-386f5c2e-ef8b-4666-98fe-cfa58be4b668.png)

