### PR TITLE
VSL-110: Renamed contracts to enable deployment

### DIFF
--- a/contracts/DAOTreasury.cdc
+++ b/contracts/DAOTreasury.cdc
@@ -1,8 +1,8 @@
-import MyMultiSig from "./MyMultiSig.cdc"
+import MyMultiSigV2 from "./MyMultiSig.cdc"
 import FungibleToken from "./core/FungibleToken.cdc"
 import NonFungibleToken from "./core/NonFungibleToken.cdc"
 
-pub contract DAOTreasury {
+pub contract DAOTreasuryV2 {
 
   pub let TreasuryStoragePath: StoragePath
   pub let TreasuryPublicPath: PublicPath
@@ -21,25 +21,25 @@ pub contract DAOTreasury {
 
   // Interfaces + Resources
   pub resource interface TreasuryPublic {
-    pub fun proposeAction(action: {MyMultiSig.Action}, signaturePayload: MyMultiSig.MessageSignaturePayload): UInt64
-    pub fun executeAction(actionUUID: UInt64, signaturePayload: MyMultiSig.MessageSignaturePayload)
-    pub fun signerDepositCollection(collection: @NonFungibleToken.Collection, signaturePayload: MyMultiSig.MessageSignaturePayload)
+    pub fun proposeAction(action: {MyMultiSigV2.Action}, signaturePayload: MyMultiSigV2.MessageSignaturePayload): UInt64
+    pub fun executeAction(actionUUID: UInt64, signaturePayload: MyMultiSigV2.MessageSignaturePayload)
+    pub fun signerDepositCollection(collection: @NonFungibleToken.Collection, signaturePayload: MyMultiSigV2.MessageSignaturePayload)
     pub fun depositTokens(identifier: String, vault: @FungibleToken.Vault)
     pub fun depositNFT(identifier: String, nft: @NonFungibleToken.NFT)
-    pub fun borrowManagerPublic(): &MyMultiSig.Manager{MyMultiSig.ManagerPublic}
+    pub fun borrowManagerPublic(): &MyMultiSigV2.Manager{MyMultiSigV2.ManagerPublic}
     pub fun borrowVaultPublic(identifier: String): &{FungibleToken.Balance}
     pub fun borrowCollectionPublic(identifier: String): &{NonFungibleToken.CollectionPublic}
     pub fun getVaultIdentifiers(): [String]
     pub fun getCollectionIdentifiers(): [String]
   }
 
-  pub resource Treasury: MyMultiSig.MultiSign, TreasuryPublic {
-    access(contract) let multiSignManager: @MyMultiSig.Manager
+  pub resource Treasury: MyMultiSigV2.MultiSign, TreasuryPublic {
+    access(contract) let multiSignManager: @MyMultiSigV2.Manager
     access(self) var vaults: @{String: FungibleToken.Vault}
     access(self) var collections: @{String: NonFungibleToken.Collection}
 
     // ------- Manager -------   
-    pub fun proposeAction(action: {MyMultiSig.Action}, signaturePayload: MyMultiSig.MessageSignaturePayload): UInt64 {
+    pub fun proposeAction(action: {MyMultiSigV2.Action}, signaturePayload: MyMultiSigV2.MessageSignaturePayload): UInt64 {
       self.validateTreasurySigner(identifier: action.intent, signaturePayload: signaturePayload)
 
       let uuid = self.multiSignManager.createMultiSign(action: action)
@@ -53,7 +53,7 @@ pub contract DAOTreasury {
       wants. This means it's very imporant for the signers
       to know what they are signing.
     */
-    pub fun executeAction(actionUUID: UInt64, signaturePayload: MyMultiSig.MessageSignaturePayload) {
+    pub fun executeAction(actionUUID: UInt64, signaturePayload: MyMultiSigV2.MessageSignaturePayload) {
       self.validateTreasurySigner(identifier: actionUUID.toString(), signaturePayload: signaturePayload)
 
       let selfRef: &Treasury = &self as &Treasury
@@ -61,7 +61,7 @@ pub contract DAOTreasury {
       emit ExecuteAction(actionUUID: actionUUID, proposer: signaturePayload.signingAddr)
     }
 
-    access(self) fun validateTreasurySigner(identifier: String, signaturePayload: MyMultiSig.MessageSignaturePayload) {
+    access(self) fun validateTreasurySigner(identifier: String, signaturePayload: MyMultiSigV2.MessageSignaturePayload) {
       // ------- Validate Address is a Signer on the Treasury -----
       let signers = self.multiSignManager.getSigners()
       assert(signers[signaturePayload.signingAddr] == true, message: "Address is not a signer on this Treasury")
@@ -94,7 +94,7 @@ pub contract DAOTreasury {
       )
 
       // ------ Validate Signature -------
-      var signatureValidationResponse = MyMultiSig.validateSignature(payload: signaturePayload)
+      var signatureValidationResponse = MyMultiSigV2.validateSignature(payload: signaturePayload)
 
       assert(
         signatureValidationResponse.isValid == true,
@@ -107,12 +107,12 @@ pub contract DAOTreasury {
     }
 
     // Reference to Manager //
-    access(account) fun borrowManager(): &MyMultiSig.Manager {
-      return &self.multiSignManager as &MyMultiSig.Manager
+    access(account) fun borrowManager(): &MyMultiSigV2.Manager {
+      return &self.multiSignManager as &MyMultiSigV2.Manager
     }
 
-    pub fun borrowManagerPublic(): &MyMultiSig.Manager{MyMultiSig.ManagerPublic} {
-      return &self.multiSignManager as &MyMultiSig.Manager{MyMultiSig.ManagerPublic}
+    pub fun borrowManagerPublic(): &MyMultiSigV2.Manager{MyMultiSigV2.ManagerPublic} {
+      return &self.multiSignManager as &MyMultiSigV2.Manager{MyMultiSigV2.ManagerPublic}
     }
 
     // ------- Vaults ------- 
@@ -147,7 +147,7 @@ pub contract DAOTreasury {
 
     // ------- Collections ------- 
 
-    pub fun signerDepositCollection(collection: @NonFungibleToken.Collection, signaturePayload: MyMultiSig.MessageSignaturePayload) {
+    pub fun signerDepositCollection(collection: @NonFungibleToken.Collection, signaturePayload: MyMultiSigV2.MessageSignaturePayload) {
       // ------- Validate Address is a Signer on the Treasury -----
       let signers = self.multiSignManager.getSigners()
       assert(signers[signaturePayload.signingAddr] == true, message: "Address is not a signer on this Treasury")
@@ -180,7 +180,7 @@ pub contract DAOTreasury {
       )
 
       // ------ Validate Signature -------
-      var signatureValidationResponse = MyMultiSig.validateSignature(payload: signaturePayload)
+      var signatureValidationResponse = MyMultiSigV2.validateSignature(payload: signaturePayload)
 
       assert(
         signatureValidationResponse.isValid == true,
@@ -236,7 +236,7 @@ pub contract DAOTreasury {
     }
 
     init(_initialSigners: [Address], _initialThreshold: UInt64) {
-      self.multiSignManager <- MyMultiSig.createMultiSigManager(signers: _initialSigners, threshold: _initialThreshold)
+      self.multiSignManager <- MyMultiSigV2.createMultiSigManager(signers: _initialSigners, threshold: _initialThreshold)
       self.vaults <- {}
       self.collections <- {}
     }

--- a/contracts/MyMultiSig.cdc
+++ b/contracts/MyMultiSig.cdc
@@ -1,7 +1,7 @@
 import Crypto
 import FungibleToken from "./core/FungibleToken.cdc"
 
-pub contract MyMultiSig {
+pub contract MyMultiSigV2 {
 
     // Events
     pub event ActionExecutedByManager(uuid: UInt64)
@@ -87,7 +87,7 @@ pub contract MyMultiSig {
             )
         
             // Validate Signature
-            var signatureValidationResponse = MyMultiSig.validateSignature(payload: _messageSignaturePayload)
+            var signatureValidationResponse = MyMultiSigV2.validateSignature(payload: _messageSignaturePayload)
             assert(signatureValidationResponse.isValid == true, message: "Invalid Signatures")
             assert(signatureValidationResponse.totalWeight >= 1000.0, message: "Total weight of combined signatures did not satisfy 1000 key weight requirement.")
 
@@ -112,7 +112,7 @@ pub contract MyMultiSig {
             )
         
             // Validate Signature
-            var signatureValidationResponse = MyMultiSig.validateSignature(payload: _messageSignaturePayload)
+            var signatureValidationResponse = MyMultiSigV2.validateSignature(payload: _messageSignaturePayload)
             assert(signatureValidationResponse.isValid == true, message: "Invalid Signatures")
             assert(signatureValidationResponse.totalWeight >= 1000.0, message: "Total weight of combined signatures did not satisfy 1000 key weight requirement.")
 

--- a/contracts/MyMultiSig.cdc
+++ b/contracts/MyMultiSig.cdc
@@ -28,6 +28,7 @@ pub contract MyMultiSig {
 
     pub struct interface Action {
         pub let intent: String
+        pub let proposer: Address
         access(account) fun execute(_ params: {String: AnyStruct})
     }
 

--- a/contracts/TreasuryActions.cdc
+++ b/contracts/TreasuryActions.cdc
@@ -60,6 +60,7 @@ pub contract TreasuryActions {
   // Transfers `amount` tokens from the treasury to `recipientVault`
   pub struct TransferToken: MyMultiSig.Action {
     pub let intent: String
+    pub let proposer: Address
     pub let recipientVault: Capability<&{FungibleToken.Receiver}>
     pub let amount: UFix64
 
@@ -77,7 +78,7 @@ pub contract TreasuryActions {
       )
     }
 
-    init(_recipientVault: Capability<&{FungibleToken.Receiver}>, _amount: UFix64) {
+    init(_recipientVault: Capability<&{FungibleToken.Receiver}>, _amount: UFix64, _proposer: Address) {
       pre {
         _amount > 0.0 : "Amount should be higher than 0.0"  
       }
@@ -90,6 +91,7 @@ pub contract TreasuryActions {
                         .concat(_recipientVault.borrow()!.owner!.address.toString())
       self.recipientVault = _recipientVault
       self.amount = _amount
+      self.proposer = _proposer
 
       emit TransferTokenToAccountActionCreated(
         recipientAddr: _recipientVault.borrow()!.owner!.address,
@@ -102,6 +104,7 @@ pub contract TreasuryActions {
   // Transfers `amount` of `identifier` tokens from the treasury to another treasury
   pub struct TransferTokenToTreasury: MyMultiSig.Action {
     pub let intent: String
+    pub let proposer: Address
     pub let identifier: String
     pub let recipientTreasury: Capability<&{DAOTreasury.TreasuryPublic}>
     pub let amount: UFix64
@@ -121,7 +124,7 @@ pub contract TreasuryActions {
       )
     }
 
-    init(_recipientTreasury: Capability<&{DAOTreasury.TreasuryPublic}>, _identifier: String, _amount: UFix64) {
+    init(_recipientTreasury: Capability<&{DAOTreasury.TreasuryPublic}>, _identifier: String, _amount: UFix64, _proposer: Address) {
       pre {
         _amount > 0.0 : "Amount should be higher than 0.0"  
       }
@@ -133,6 +136,7 @@ pub contract TreasuryActions {
                         .concat(_identifier)
                         .concat(" tokens from the treasury to ")
                         .concat(recipientAddr.toString())
+      self.proposer = _proposer
       self.identifier = _identifier
       self.recipientTreasury = _recipientTreasury
       self.amount = _amount
@@ -148,6 +152,7 @@ pub contract TreasuryActions {
   // Transfers an NFT from the treasury to `recipientCollection`
   pub struct TransferNFT: MyMultiSig.Action {
     pub let intent: String
+    pub let proposer: Address
     pub let recipientCollection: Capability<&{NonFungibleToken.CollectionPublic}>
     pub let withdrawID: UInt64
 
@@ -167,7 +172,7 @@ pub contract TreasuryActions {
       )
     }
 
-    init(_recipientCollection: Capability<&{NonFungibleToken.CollectionPublic}>, _nftID: UInt64) {
+    init(_recipientCollection: Capability<&{NonFungibleToken.CollectionPublic}>, _nftID: UInt64, _proposer: Address) {
       let recipientAddr = _recipientCollection.borrow()!.owner!.address
       let collectionID = _recipientCollection.getType().identifier
 
@@ -175,6 +180,7 @@ pub contract TreasuryActions {
                         .concat(collectionID)
                         .concat(" NFT from the treasury to ")
                         .concat(recipientAddr.toString())
+      self.proposer = _proposer
       self.recipientCollection = _recipientCollection
       self.withdrawID = _nftID
       emit TransferNFTToAccountActionCreated(
@@ -185,9 +191,10 @@ pub contract TreasuryActions {
     }
   }
 
-    // Transfers an NFT from the treasury to another treasury
+  // Transfers an NFT from the treasury to another treasury
   pub struct TransferNFTToTreasury: MyMultiSig.Action {
     pub let intent: String
+    pub let proposer: Address
     pub let identifier: String
     pub let recipientTreasury: Capability<&{DAOTreasury.TreasuryPublic}>
     pub let withdrawID: UInt64
@@ -207,7 +214,7 @@ pub contract TreasuryActions {
       )
     }
 
-    init(_recipientTreasury: Capability<&{DAOTreasury.TreasuryPublic}>, _identifier: String, _nftID: UInt64) {
+    init(_recipientTreasury: Capability<&{DAOTreasury.TreasuryPublic}>, _identifier: String, _nftID: UInt64, _proposer: Address) {
       let recipientAddr = _recipientTreasury.borrow()!.owner!.address
       self.intent = "Transfer an NFT from collection"
                         .concat(" ")
@@ -215,11 +222,12 @@ pub contract TreasuryActions {
                         .concat(" with ID ")
                         .concat(_nftID.toString())
                         .concat(" ")
-                        .concat(" from this Treasury to Treasury at address ")
+                        .concat("from this Treasury to Treasury at address ")
                         .concat(recipientAddr.toString())
       self.identifier = _identifier
       self.recipientTreasury = _recipientTreasury
-      self.withdrawID= _nftID
+      self.withdrawID = _nftID
+      self.proposer = _proposer
 
       emit TransferNFTToTreasuryActionCreated(
         recipientAddr: recipientAddr,
@@ -233,6 +241,7 @@ pub contract TreasuryActions {
   pub struct AddSigner: MyMultiSig.Action {
     pub let signer: Address
     pub let intent: String
+    pub let proposer: Address
 
     access(account) fun execute(_ params: {String: AnyStruct}) {
       let treasuryRef: &DAOTreasury.Treasury = params["treasury"]! as! &DAOTreasury.Treasury
@@ -243,7 +252,8 @@ pub contract TreasuryActions {
       emit AddSignerActionExecuted(address: self.signer, treasuryAddr: treasuryRef.owner!.address)
     }
 
-    init(_signer: Address) {
+    init(_signer: Address, _proposer: Address) {
+      self.proposer = _proposer
       self.signer = _signer
       self.intent = "Add account "
                       .concat(_signer.toString())
@@ -256,6 +266,7 @@ pub contract TreasuryActions {
   pub struct RemoveSigner: MyMultiSig.Action {
     pub let signer: Address
     pub let intent: String
+    pub let proposer: Address
 
     access(account) fun execute(_ params: {String: AnyStruct}) {
       let treasuryRef: &DAOTreasury.Treasury = params["treasury"]! as! &DAOTreasury.Treasury
@@ -265,7 +276,8 @@ pub contract TreasuryActions {
       emit RemoveSignerActionExecuted(address: self.signer, treasuryAddr: treasuryRef.owner!.address)
     }
 
-    init(_signer: Address) {
+    init(_signer: Address, _proposer: Address) {
+      self.proposer = _proposer
       self.signer = _signer
       self.intent = "Remove "
                       .concat(_signer.toString())
@@ -278,6 +290,7 @@ pub contract TreasuryActions {
   pub struct UpdateThreshold: MyMultiSig.Action {
     pub let threshold: UInt64
     pub let intent: String
+    pub let proposer: Address
 
     access(account) fun execute(_ params: {String: AnyStruct}) {
       let treasuryRef: &DAOTreasury.Treasury = params["treasury"]! as! &DAOTreasury.Treasury
@@ -288,9 +301,10 @@ pub contract TreasuryActions {
       emit UpdateThresholdActionExecuted(oldThreshold: oldThreshold, newThreshold: self.threshold, treasuryAddr: treasuryRef.owner!.address)
     }
 
-    init(_threshold: UInt64) {
+    init(_threshold: UInt64, _proposer: Address) {
       self.threshold = _threshold
-      self.intent = "Update the threshold of signers needed to execute an action in the Treasury."
+      self.proposer = _proposer
+      self.intent = "Update the threshold of signers to ".concat(_threshold.toString()).concat(".")
       emit UpdateThresholdActionCreated(threshold: _threshold)
     }
   }
@@ -299,6 +313,7 @@ pub contract TreasuryActions {
   pub struct DestroyAction: MyMultiSig.Action {
     pub let actionUUID: UInt64
     pub let intent: String
+    pub let proposer: Address
 
     access(account) fun execute(_ params: {String: AnyStruct}) {
       let treasuryRef: &DAOTreasury.Treasury = params["treasury"]! as! &DAOTreasury.Treasury
@@ -308,9 +323,12 @@ pub contract TreasuryActions {
       emit DestroyActionActionExecuted(actionUUID: self.actionUUID, treasuryAddr: treasuryRef.owner!.address)
     }
 
-    init(_actionUUID: UInt64) {
+    init(_actionUUID: UInt64, _proposer: Address) {
       self.actionUUID = _actionUUID
-      self.intent = "Remove the action from the Treasury."
+      self.proposer = _proposer
+      self.intent = "Remove the action "
+                      .concat(_actionUUID.toString())
+                      .concat(" from the Treasury.")
       emit DestroyActionActionCreated(actionUUID: _actionUUID)
     }
   }

--- a/contracts/TreasuryActions.cdc
+++ b/contracts/TreasuryActions.cdc
@@ -1,9 +1,9 @@
-import MyMultiSig from "./MyMultiSig.cdc"
-import DAOTreasury from "./DAOTreasury.cdc"
+import MyMultiSigV2 from "./MyMultiSig.cdc"
+import DAOTreasuryV2 from "./DAOTreasury.cdc"
 import FungibleToken from "./core/FungibleToken.cdc"
 import NonFungibleToken from "./core/NonFungibleToken.cdc"
 
-pub contract TreasuryActions {
+pub contract TreasuryActionsV2 {
 
   ///////////
   // Events
@@ -58,14 +58,14 @@ pub contract TreasuryActions {
   pub event DestroyActionActionExecuted(actionUUID: UInt64, treasuryAddr: Address)
 
   // Transfers `amount` tokens from the treasury to `recipientVault`
-  pub struct TransferToken: MyMultiSig.Action {
+  pub struct TransferToken: MyMultiSigV2.Action {
     pub let intent: String
     pub let proposer: Address
     pub let recipientVault: Capability<&{FungibleToken.Receiver}>
     pub let amount: UFix64
 
     access(account) fun execute(_ params: {String: AnyStruct}) {
-      let treasuryRef: &DAOTreasury.Treasury = params["treasury"]! as! &DAOTreasury.Treasury
+      let treasuryRef: &DAOTreasuryV2.Treasury = params["treasury"]! as! &DAOTreasuryV2.Treasury
       let vaultID: String = self.recipientVault.borrow()!.getType().identifier
       let withdrawnTokens <- treasuryRef.withdrawTokens(identifier: vaultID, amount: self.amount)
       self.recipientVault.borrow()!.deposit(from: <- withdrawnTokens)
@@ -102,15 +102,15 @@ pub contract TreasuryActions {
   }
 
   // Transfers `amount` of `identifier` tokens from the treasury to another treasury
-  pub struct TransferTokenToTreasury: MyMultiSig.Action {
+  pub struct TransferTokenToTreasury: MyMultiSigV2.Action {
     pub let intent: String
     pub let proposer: Address
     pub let identifier: String
-    pub let recipientTreasury: Capability<&{DAOTreasury.TreasuryPublic}>
+    pub let recipientTreasury: Capability<&{DAOTreasuryV2.TreasuryPublic}>
     pub let amount: UFix64
 
     access(account) fun execute(_ params: {String: AnyStruct}) {
-      let treasuryRef: &DAOTreasury.Treasury = params["treasury"]! as! &DAOTreasury.Treasury
+      let treasuryRef: &DAOTreasuryV2.Treasury = params["treasury"]! as! &DAOTreasuryV2.Treasury
       let withdrawnTokens <- treasuryRef.withdrawTokens(identifier: self.identifier, amount: self.amount)
 
       let recipientAddr = self.recipientTreasury.borrow()!.owner!.address
@@ -124,7 +124,7 @@ pub contract TreasuryActions {
       )
     }
 
-    init(_recipientTreasury: Capability<&{DAOTreasury.TreasuryPublic}>, _identifier: String, _amount: UFix64, _proposer: Address) {
+    init(_recipientTreasury: Capability<&{DAOTreasuryV2.TreasuryPublic}>, _identifier: String, _amount: UFix64, _proposer: Address) {
       pre {
         _amount > 0.0 : "Amount should be higher than 0.0"  
       }
@@ -150,14 +150,14 @@ pub contract TreasuryActions {
   }
 
   // Transfers an NFT from the treasury to `recipientCollection`
-  pub struct TransferNFT: MyMultiSig.Action {
+  pub struct TransferNFT: MyMultiSigV2.Action {
     pub let intent: String
     pub let proposer: Address
     pub let recipientCollection: Capability<&{NonFungibleToken.CollectionPublic}>
     pub let withdrawID: UInt64
 
     access(account) fun execute(_ params: {String: AnyStruct}) {
-      let treasuryRef: &DAOTreasury.Treasury = params["treasury"]! as! &DAOTreasury.Treasury
+      let treasuryRef: &DAOTreasuryV2.Treasury = params["treasury"]! as! &DAOTreasuryV2.Treasury
       let collectionID = self.recipientCollection.borrow()!.getType().identifier
       
       let nft <- treasuryRef.withdrawNFT(identifier: collectionID, id: self.withdrawID)
@@ -192,15 +192,15 @@ pub contract TreasuryActions {
   }
 
   // Transfers an NFT from the treasury to another treasury
-  pub struct TransferNFTToTreasury: MyMultiSig.Action {
+  pub struct TransferNFTToTreasury: MyMultiSigV2.Action {
     pub let intent: String
     pub let proposer: Address
     pub let identifier: String
-    pub let recipientTreasury: Capability<&{DAOTreasury.TreasuryPublic}>
+    pub let recipientTreasury: Capability<&{DAOTreasuryV2.TreasuryPublic}>
     pub let withdrawID: UInt64
 
     access(account) fun execute(_ params: {String: AnyStruct}) {
-      let treasuryRef: &DAOTreasury.Treasury = params["treasury"]! as! &DAOTreasury.Treasury
+      let treasuryRef: &DAOTreasuryV2.Treasury = params["treasury"]! as! &DAOTreasuryV2.Treasury
       let nft <- treasuryRef.withdrawNFT(identifier: self.identifier, id: self.withdrawID)
 
       let recipientCollectionRef: &{NonFungibleToken.CollectionPublic} = self.recipientTreasury.borrow()!.borrowCollectionPublic(identifier: self.identifier)
@@ -214,7 +214,7 @@ pub contract TreasuryActions {
       )
     }
 
-    init(_recipientTreasury: Capability<&{DAOTreasury.TreasuryPublic}>, _identifier: String, _nftID: UInt64, _proposer: Address) {
+    init(_recipientTreasury: Capability<&{DAOTreasuryV2.TreasuryPublic}>, _identifier: String, _nftID: UInt64, _proposer: Address) {
       let recipientAddr = _recipientTreasury.borrow()!.owner!.address
       self.intent = "Transfer an NFT from collection"
                         .concat(" ")
@@ -238,13 +238,13 @@ pub contract TreasuryActions {
   }
 
   // Add a new signer to the treasury
-  pub struct AddSigner: MyMultiSig.Action {
+  pub struct AddSigner: MyMultiSigV2.Action {
     pub let signer: Address
     pub let intent: String
     pub let proposer: Address
 
     access(account) fun execute(_ params: {String: AnyStruct}) {
-      let treasuryRef: &DAOTreasury.Treasury = params["treasury"]! as! &DAOTreasury.Treasury
+      let treasuryRef: &DAOTreasuryV2.Treasury = params["treasury"]! as! &DAOTreasuryV2.Treasury
 
       let manager = treasuryRef.borrowManager()
       manager.addSigner(signer: self.signer)
@@ -263,13 +263,13 @@ pub contract TreasuryActions {
   }
 
   // Remove a signer from the treasury
-  pub struct RemoveSigner: MyMultiSig.Action {
+  pub struct RemoveSigner: MyMultiSigV2.Action {
     pub let signer: Address
     pub let intent: String
     pub let proposer: Address
 
     access(account) fun execute(_ params: {String: AnyStruct}) {
-      let treasuryRef: &DAOTreasury.Treasury = params["treasury"]! as! &DAOTreasury.Treasury
+      let treasuryRef: &DAOTreasuryV2.Treasury = params["treasury"]! as! &DAOTreasuryV2.Treasury
 
       let manager = treasuryRef.borrowManager()
       manager.removeSigner(signer: self.signer)
@@ -287,13 +287,13 @@ pub contract TreasuryActions {
   }
 
   // Update the threshold of signers
-  pub struct UpdateThreshold: MyMultiSig.Action {
+  pub struct UpdateThreshold: MyMultiSigV2.Action {
     pub let threshold: UInt64
     pub let intent: String
     pub let proposer: Address
 
     access(account) fun execute(_ params: {String: AnyStruct}) {
-      let treasuryRef: &DAOTreasury.Treasury = params["treasury"]! as! &DAOTreasury.Treasury
+      let treasuryRef: &DAOTreasuryV2.Treasury = params["treasury"]! as! &DAOTreasuryV2.Treasury
 
       let manager = treasuryRef.borrowManager()
       let oldThreshold = manager.threshold
@@ -310,13 +310,13 @@ pub contract TreasuryActions {
   }
 
   // Destroy the action
-  pub struct DestroyAction: MyMultiSig.Action {
+  pub struct DestroyAction: MyMultiSigV2.Action {
     pub let actionUUID: UInt64
     pub let intent: String
     pub let proposer: Address
 
     access(account) fun execute(_ params: {String: AnyStruct}) {
-      let treasuryRef: &DAOTreasury.Treasury = params["treasury"]! as! &DAOTreasury.Treasury
+      let treasuryRef: &DAOTreasuryV2.Treasury = params["treasury"]! as! &DAOTreasuryV2.Treasury
 
       let manager = treasuryRef.borrowManager()
       manager.destroyAction(actionUUID: self.actionUUID)

--- a/flow.json
+++ b/flow.json
@@ -39,19 +39,19 @@
 			}
 		},
 		"ExampleNFT": "./contracts/core/ExampleNFT.cdc",
-		"MyMultiSig": {
+		"MyMultiSigV2": {
 			"source": "./contracts/MyMultiSig.cdc",
 			"aliases": {
 				"testnet": "0x68a4fe55ec686656"
 			}
 		},
-		"DAOTreasury": {
+		"DAOTreasuryV2": {
 			"source": "./contracts/DAOTreasury.cdc",
 			"aliases": {
 				"testnet": "0x68a4fe55ec686656"
 			}
 		},
-		"TreasuryActions": {
+		"TreasuryActionsV2": {
 			"source": "./contracts/TreasuryActions.cdc",
 			"aliases": {
 				"testnet": "0x68a4fe55ec686656"
@@ -174,9 +174,9 @@
 				"NonFungibleToken",
 				"MetadataViews",
 				"ExampleNFT",
-				"MyMultiSig",
-				"DAOTreasury",
-				"TreasuryActions"
+				"MyMultiSigV2",
+				"DAOTreasuryV2",
+				"TreasuryActionsV2"
 			],
 			"emulator-recipient": [],
 			"emulator-signer1": [],
@@ -204,9 +204,9 @@
 		},
 		"testnet": {
 			"testnet-account": [
-				"MyMultiSig",
-				"DAOTreasury",
-				"TreasuryActions"
+				"MyMultiSigV2",
+				"DAOTreasuryV2",
+				"TreasuryActionsV2"
 			]
 		}
 	}

--- a/main_test.go
+++ b/main_test.go
@@ -483,7 +483,7 @@ func TestAddSignerAction(t *testing.T) {
 	otu.SetupTreasury("treasuryOwner", signers, uint64(len(signers)))
 
 	t.Run("User should be able to propose a signer to be added", func(t *testing.T) {
-		otu.ProposeAddSignerAction("treasuryOwner", "signer4")
+		otu.ProposeAddSignerAction("treasuryOwner", "treasuryOwner", "signer4")
 	})
 
 	t.Run("Signers should be able to sign to approve a proposed action to add a new signer", func(t *testing.T) {
@@ -525,7 +525,7 @@ func TestRemoveSignerAction(t *testing.T) {
 	otu.SetupTreasury("treasuryOwner", Signers, 3)
 
 	t.Run("User should be able to propose a signer to be removed", func(t *testing.T) {
-		otu.ProposeRemoveSignerAction("treasuryOwner", "signer4")
+		otu.ProposeRemoveSignerAction("treasuryOwner", "treasuryOwner", "signer4")
 	})
 
 	t.Run("Signers should be able to sign to approve a proposed action to remove a signer", func(t *testing.T) {
@@ -566,7 +566,7 @@ func TestRemoveSignerActionErrors(t *testing.T) {
 	otu.SetupTreasury("treasuryOwner", Signers, DefaultThreshold)
 
 	t.Run("User should be able to propose a signer to be removed", func(t *testing.T) {
-		otu.ProposeRemoveSignerAction("treasuryOwner", "signer4")
+		otu.ProposeRemoveSignerAction("treasuryOwner", "treasuryOwner", "signer4")
 	})
 
 	t.Run("Signers should be able to sign to approve a proposed action to remove a signer", func(t *testing.T) {
@@ -608,7 +608,7 @@ func TestUpdateThreshold(t *testing.T) {
 	otu.SetupTreasury("treasuryOwner", Signers, 2)
 
 	t.Run("User should be able to propose an update to the threshold", func(t *testing.T) {
-		otu.ProposeNewThreshold("treasuryOwner", DefaultThreshold)
+		otu.ProposeNewThreshold("treasuryOwner", "treasuryOwner", DefaultThreshold)
 	})
 
 	t.Run("Signers should be able to sign to approve a proposed action to update the threshold", func(t *testing.T) {
@@ -642,7 +642,7 @@ func TestUpdateThreshold(t *testing.T) {
 	})
 
 	t.Run("User shouldn't be able to propose an update to the threshold which is bigger than the number of signers", func(t *testing.T) {
-		otu.ProposeNewThreshold("treasuryOwner", 10)
+		otu.ProposeNewThreshold("treasuryOwner", "treasuryOwner", 10)
 
 		actions := otu.GetProposedActions("treasuryOwner")
 		keys := make([]uint64, 0, len(actions))
@@ -713,7 +713,7 @@ func TestDestroyAction(t *testing.T) {
 	otu.SetupTreasury("treasuryOwner", Signers, 2)
 
 	t.Run("User should be able to propose an action", func(t *testing.T) {
-		otu.ProposeNewThreshold("treasuryOwner", DefaultThreshold)
+		otu.ProposeNewThreshold("treasuryOwner", "treasuryOwner", DefaultThreshold)
 	})
 
 	t.Run("User should be able to propose to destroy the action", func(t *testing.T) {

--- a/main_test.go
+++ b/main_test.go
@@ -11,9 +11,9 @@ var NonFungibleTokenCollectionID = "A.f8d6e0586b0a20c7.ExampleNFT.Collection"
 var DefaultAccountBalance uint64 = 1e5
 var TransferAmount float64 = 100
 var TransferAmountUInt64 uint64 = 100e8
-var Signers = []string{"signer1", "signer2", "signer3", "signer4"}
+var Signers = []string{"treasuryOwner", "signer1", "signer2", "signer3", "signer4"}
 var DefaultThreshold = uint64(len(Signers))
-var MaxSigners = GenerateSigners(20)
+var MaxSigners = append(GenerateSigners(20), "treasuryOwner")
 var MaxThreshold = 20
 var RecipientAcct = "recipient"
 
@@ -477,7 +477,7 @@ func TestSignerRevokeApproval(t *testing.T) {
 func TestAddSignerAction(t *testing.T) {
 	var addSignerActionUUID uint64
 
-	var signers = []string{"signer1", "signer2", "signer3"}
+	var signers = []string{"treasuryOwner", "signer1", "signer2", "signer3"}
 
 	otu := NewOverflowTest(t)
 	otu.SetupTreasury("treasuryOwner", signers, uint64(len(signers)))
@@ -728,6 +728,13 @@ func TestDestroyAction(t *testing.T) {
 	})
 
 	t.Run("Signers should be able to sign to approve a proposed destroy action", func(t *testing.T) {
+
+		actions := otu.GetProposedActions("treasuryOwner")
+		keys := make([]uint64, 0, len(actions))
+		for k := range actions {
+			keys = append(keys, k)
+		}
+		actionUUID = keys[0]
 
 		// Each signer submits an approval signature
 		for _, signer := range Signers {

--- a/nft.js
+++ b/nft.js
@@ -20,7 +20,7 @@ const deployNFTCollection = () => {
       console.log(stdout);
 
       exec(
-        `flow transactions send ${mintNFT} 0x${address} testName testDescription https://tinyurl.com/j5dehtjv`,
+        `flow transactions send ${mintNFT} 0x${address} testName testDescription https://i.natgeofe.com/n/46b07b5e-1264-42e1-ae4b-8a021226e2d0/domestic-cat_thumb.jpg`,
         (error, stdout, stderr) => {
           if (error?.message || stderr) {
             console.log(`error sending nft: ${error.message}`);

--- a/nft.js
+++ b/nft.js
@@ -10,7 +10,7 @@ const deployNFTCollection = () => {
   const sendNFT = `${basePath}/send_nft_to_treasury.cdc`;
 
   exec(
-    `flow transactions send ${mintNFT} 0x${address} testName testDescription testThumbnail.jpg`,
+    `flow transactions send ${mintNFT} 0x${address} testName testDescription https://i.natgeofe.com/n/46b07b5e-1264-42e1-ae4b-8a021226e2d0/domestic-cat_thumb.jpg`,
     (error, stdout, stderr) => {
       if (error?.message || stderr) {
         console.log(`error minting nft: ${error.message}`);
@@ -20,7 +20,7 @@ const deployNFTCollection = () => {
       console.log(stdout);
 
       exec(
-        `flow transactions send ${mintNFT} 0x${address} testName testDescription https://i.natgeofe.com/n/46b07b5e-1264-42e1-ae4b-8a021226e2d0/domestic-cat_thumb.jpg`,
+        `flow transactions send ${sendNFT} 0x${address} 0`,
         (error, stdout, stderr) => {
           if (error?.message || stderr) {
             console.log(`error sending nft: ${error.message}`);

--- a/packages/client/src/components/ActionsList.js
+++ b/packages/client/src/components/ActionsList.js
@@ -16,7 +16,6 @@ function ActionsList({ actions = [], onSign, onConfirm, safeData }) {
   } else {
     actions.forEach((action, idx) => {
       const borderClass = idx < actions.length - 1 ? "border-light-top" : ``;
-      const totalSigs = Object.keys(action.verifiedSigners).length;
       const totalSigned = Object.values(action.verifiedSigners).filter(
         (x) => x
       ).length;

--- a/packages/client/src/contexts/Web3.js
+++ b/packages/client/src/contexts/Web3.js
@@ -4,6 +4,13 @@ import networks from "../networks";
 import { useRouteMatch } from "react-router-dom";
 import { useFclUser, useTreasury, useNFTs } from "../hooks";
 
+export const REGULAR_LIMIT = 55;
+export const CREATE_TREASURY_LIMIT = 80;
+export const UPDATE_SIGNER_LIMIT = 110;
+export const SIGNED_LIMIT = 300;
+export const SIGNER_APPROVE_LIMIT = 310;
+export const EXECUTE_ACTION_LIMIT = 350;
+
 // create our app context
 export const Web3Context = React.createContext({});
 
@@ -111,4 +118,32 @@ export function Web3Consumer(Component) {
       </Web3Context.Consumer>
     );
   };
+}
+
+export const createSignature = async (intent) => {
+  try {
+    const latestBlock = await fcl
+      .send([fcl.getBlock(true)])
+      .then(fcl.decode);
+
+    const { height, id } = latestBlock;
+    const intentHex = Buffer.from(intent).toString("hex");
+
+    const message = `${intentHex}${id}`;
+    const messageHex = Buffer.from(message).toString("hex");
+
+    let sigResponse = await fcl
+      .currentUser()
+      .signUserMessage(messageHex);
+    const sigMessage =
+      sigResponse[0]?.signature?.signature ?? sigResponse[0]?.signature;
+    const keyIds = [sigResponse[0]?.keyId];
+    const signatures = [sigMessage];
+
+    return {
+      message, keyIds, signatures, height
+    }
+  } catch (error) {
+    console.log("error in creating a signature", error)
+  }
 }

--- a/packages/client/src/flow/addSigner.tx.js
+++ b/packages/client/src/flow/addSigner.tx.js
@@ -1,19 +1,19 @@
 export const ADD_SIGNER = `
-  import DAOTreasury from 0xDAOTreasury
-  import TreasuryActions from 0xTreasuryActions
-  import MyMultiSig from 0xMyMultiSig
+  import DAOTreasuryV2 from 0xDAOTreasuryV2
+  import TreasuryActionsV2 from 0xTreasuryActionsV2
+  import MyMultiSigV2 from 0xMyMultiSigV2
 
   transaction(treasuryAddr: Address, additionalSigner: Address, message: String, keyIds: [UInt64], signatures: [String], signatureBlock: UInt64) {
   
-    let treasury: &DAOTreasury.Treasury{DAOTreasury.TreasuryPublic}
-    let action: AnyStruct{MyMultiSig.Action}
-    let messageSignaturePayload: MyMultiSig.MessageSignaturePayload
+    let treasury: &DAOTreasuryV2.Treasury{DAOTreasuryV2.TreasuryPublic}
+    let action: AnyStruct{MyMultiSigV2.Action}
+    let messageSignaturePayload: MyMultiSigV2.MessageSignaturePayload
   
     prepare(signer: AuthAccount) {
-      self.treasury = getAccount(treasuryAddr).getCapability(DAOTreasury.TreasuryPublicPath)
-                      .borrow<&DAOTreasury.Treasury{DAOTreasury.TreasuryPublic}>()
-                      ?? panic("A DAOTreasury doesn't exist here.")
-      self.action = TreasuryActions.AddSigner(_signer: additionalSigner, _proposer: signer.address)
+      self.treasury = getAccount(treasuryAddr).getCapability(DAOTreasuryV2.TreasuryPublicPath)
+                      .borrow<&DAOTreasuryV2.Treasury{DAOTreasuryV2.TreasuryPublic}>()
+                      ?? panic("A DAOTreasuryV2 doesn't exist here.")
+      self.action = TreasuryActionsV2.AddSigner(_signer: additionalSigner, _proposer: signer.address)
       
       var _keyIds: [Int] = []
   
@@ -21,7 +21,7 @@ export const ADD_SIGNER = `
           _keyIds.append(Int(keyId))
       }
   
-      self.messageSignaturePayload = MyMultiSig.MessageSignaturePayload(
+      self.messageSignaturePayload = MyMultiSigV2.MessageSignaturePayload(
           _signingAddr: signer.address, _message: message, _keyIds: _keyIds, _signatures: signatures, _signatureBlock: signatureBlock
       )
     }

--- a/packages/client/src/flow/addSigner.tx.js
+++ b/packages/client/src/flow/addSigner.tx.js
@@ -3,15 +3,16 @@ export const ADD_SIGNER = `
   import TreasuryActions from 0xTreasuryActions
   import MyMultiSig from 0xMyMultiSig
 
-  transaction(additionalSigner: Address, message: String, keyIds: [UInt64], signatures: [String], signatureBlock: UInt64) {
-    
+  transaction(treasuryAddr: Address, additionalSigner: Address, message: String, keyIds: [UInt64], signatures: [String], signatureBlock: UInt64) {
+  
     let treasury: &DAOTreasury.Treasury{DAOTreasury.TreasuryPublic}
     let action: AnyStruct{MyMultiSig.Action}
     let messageSignaturePayload: MyMultiSig.MessageSignaturePayload
   
     prepare(signer: AuthAccount) {
-      self.treasury = signer.borrow<&DAOTreasury.Treasury>(from: DAOTreasury.TreasuryStoragePath)
-                      ?? panic("Could not borrow the DAOTreasury")
+      self.treasury = getAccount(treasuryAddr).getCapability(DAOTreasury.TreasuryPublicPath)
+                      .borrow<&DAOTreasury.Treasury{DAOTreasury.TreasuryPublic}>()
+                      ?? panic("A DAOTreasury doesn't exist here.")
       self.action = TreasuryActions.AddSigner(additionalSigner, signer.address)
       
       var _keyIds: [Int] = []

--- a/packages/client/src/flow/addSigner.tx.js
+++ b/packages/client/src/flow/addSigner.tx.js
@@ -1,18 +1,31 @@
 export const ADD_SIGNER = `
-import DAOTreasury from 0xDAOTreasury
-import TreasuryActions from 0xTreasuryActions
+  import DAOTreasury from 0xDAOTreasury
+  import TreasuryActions from 0xTreasuryActions
+  import MyMultiSig from 0xMyMultiSig
 
-  transaction(additionalSigner: Address) {
+  transaction(additionalSigner: Address, message: String, keyIds: [UInt64], signatures: [String], signatureBlock: UInt64) {
     
-    let Treasury: &DAOTreasury.Treasury{DAOTreasury.TreasuryPublic}
-
+    let treasury: &DAOTreasury.Treasury{DAOTreasury.TreasuryPublic}
+    let action: AnyStruct{MyMultiSig.Action}
+    let messageSignaturePayload: MyMultiSig.MessageSignaturePayload
+  
     prepare(signer: AuthAccount) {
-      self.Treasury = signer.borrow<&DAOTreasury.Treasury>(from: DAOTreasury.TreasuryStoragePath)
+      self.treasury = signer.borrow<&DAOTreasury.Treasury>(from: DAOTreasury.TreasuryStoragePath)
                       ?? panic("Could not borrow the DAOTreasury")
+      self.action = TreasuryActions.AddSigner(additionalSigner, signer.address)
+      
+      var _keyIds: [Int] = []
+  
+      for keyId in keyIds {
+          _keyIds.append(Int(keyId))
+      }
+  
+      self.messageSignaturePayload = MyMultiSig.MessageSignaturePayload(
+          _signingAddr: signer.address, _message: message, _keyIds: _keyIds, _signatures: signatures, _signatureBlock: signatureBlock
+      )
     }
     execute {
-      let action = TreasuryActions.AddSigner(_signer: additionalSigner)
-      self.Treasury.proposeAction(action: action)
+      self.treasury.proposeAction(action: self.action, signaturePayload: self.messageSignaturePayload)
     }
   }
 `;

--- a/packages/client/src/flow/checkTreasuries.tx.js
+++ b/packages/client/src/flow/checkTreasuries.tx.js
@@ -1,11 +1,11 @@
 const treasury = `
-	let treasury = getAccount(treasuryAddr).getCapability(DAOTreasury.TreasuryPublicPath)
-										.borrow<&DAOTreasury.Treasury{DAOTreasury.TreasuryPublic}>()
-										?? panic("A DAOTreasury doesn't exist here.")
+	let treasury = getAccount(treasuryAddr).getCapability(DAOTreasuryV2.TreasuryPublicPath)
+										.borrow<&DAOTreasuryV2.Treasury{DAOTreasuryV2.TreasuryPublic}>()
+										?? panic("A DAOTreasuryV2 doesn't exist here.")
 `;
 
 export const GET_SIGNERS = `
-	import DAOTreasury from 0xDAOTreasury
+	import DAOTreasuryV2 from 0xDAOTreasuryV2
 	pub fun main(treasuryAddr: Address): {Address: Bool} {
 		${treasury}
 		return treasury.borrowManagerPublic().getSigners()
@@ -13,7 +13,7 @@ export const GET_SIGNERS = `
 `;
 
 export const GET_THRESHOLD = `
-	import DAOTreasury from 0xDAOTreasury
+	import DAOTreasuryV2 from 0xDAOTreasuryV2
 
 	pub fun main(treasuryAddr: Address): UInt64 {
 		${treasury}

--- a/packages/client/src/flow/checkTreasuryNFTCollection.tx.js
+++ b/packages/client/src/flow/checkTreasuryNFTCollection.tx.js
@@ -1,11 +1,11 @@
 export const CHECK_TREASURY_NFT_COLLECTION = `
-  import DAOTreasury from 0xDAOTreasury
+  import DAOTreasuryV2 from 0xDAOTreasuryV2
   import NonFungibleToken from 0xNonFungibleToken
 
   pub fun main(treasuryAddr: Address, collectionId: String): [&NonFungibleToken.NFT] {
-    let treasury = getAccount(treasuryAddr).getCapability(DAOTreasury.TreasuryPublicPath)
-                      .borrow<&DAOTreasury.Treasury{DAOTreasury.TreasuryPublic}>()
-                      ?? panic("A DAOTreasury doesn't exist here.")
+    let treasury = getAccount(treasuryAddr).getCapability(DAOTreasuryV2.TreasuryPublicPath)
+                      .borrow<&DAOTreasuryV2.Treasury{DAOTreasuryV2.TreasuryPublic}>()
+                      ?? panic("A DAOTreasuryV2 doesn't exist here.")
 
     let collection: &{NonFungibleToken.CollectionPublic} = treasury.borrowCollectionPublic(identifier: collectionId)
     let ids = collection.getIDs()

--- a/packages/client/src/flow/executeAction.tx.js
+++ b/packages/client/src/flow/executeAction.tx.js
@@ -1,17 +1,28 @@
 export const EXECUTE_ACTION = `
 	import DAOTreasury from 0xDAOTreasury
+	import MyMultiSig from 0xMyMultiSig
 
-	transaction(treasuryAddr: Address, actionUUID: UInt64) {
+	transaction(treasuryAddr: Address, actionUUID: UInt64, message: String, keyIds: [UInt64], signatures: [String], signatureBlock: UInt64) {
 
-		let Treasury: &DAOTreasury.Treasury{DAOTreasury.TreasuryPublic}
+		let treasury: &DAOTreasury.Treasury{DAOTreasury.TreasuryPublic}
+		let messageSignaturePayload: MyMultiSig.MessageSignaturePayload
 		
 		prepare(signer: AuthAccount) {
-		  self.Treasury = getAccount(treasuryAddr).getCapability(DAOTreasury.TreasuryPublicPath)
+		  self.treasury = getAccount(treasuryAddr).getCapability(DAOTreasury.TreasuryPublicPath)
 						  .borrow<&DAOTreasury.Treasury{DAOTreasury.TreasuryPublic}>()
-						  ?? panic("A DAOTreasury doesn't exist here.")        
+						  ?? panic("A DAOTreasury doesn't exist here.")
+		  var _keyIds: [Int] = []
+	  
+		  for keyId in keyIds {
+			  _keyIds.append(Int(keyId))
+		  }
+	  
+		  self.messageSignaturePayload = MyMultiSig.MessageSignaturePayload(
+			  _signingAddr: signer.address, _message: message, _keyIds: _keyIds, _signatures: signatures, _signatureBlock: signatureBlock
+		  )
 		}
 		execute {
-		  self.Treasury.executeAction(actionUUID: actionUUID)
+		  self.treasury.executeAction(actionUUID: actionUUID, signaturePayload: self.messageSignaturePayload)
 		}
 	  }
 `;

--- a/packages/client/src/flow/executeAction.tx.js
+++ b/packages/client/src/flow/executeAction.tx.js
@@ -1,23 +1,23 @@
 export const EXECUTE_ACTION = `
-	import DAOTreasury from 0xDAOTreasury
-	import MyMultiSig from 0xMyMultiSig
+	import DAOTreasuryV2 from 0xDAOTreasuryV2
+	import MyMultiSigV2 from 0xMyMultiSigV2
 
 	transaction(treasuryAddr: Address, actionUUID: UInt64, message: String, keyIds: [UInt64], signatures: [String], signatureBlock: UInt64) {
 
-		let treasury: &DAOTreasury.Treasury{DAOTreasury.TreasuryPublic}
-		let messageSignaturePayload: MyMultiSig.MessageSignaturePayload
+		let treasury: &DAOTreasuryV2.Treasury{DAOTreasuryV2.TreasuryPublic}
+		let messageSignaturePayload: MyMultiSigV2.MessageSignaturePayload
 		
 		prepare(signer: AuthAccount) {
-		  self.treasury = getAccount(treasuryAddr).getCapability(DAOTreasury.TreasuryPublicPath)
-						  .borrow<&DAOTreasury.Treasury{DAOTreasury.TreasuryPublic}>()
-						  ?? panic("A DAOTreasury doesn't exist here.")
+		  self.treasury = getAccount(treasuryAddr).getCapability(DAOTreasuryV2.TreasuryPublicPath)
+						  .borrow<&DAOTreasuryV2.Treasury{DAOTreasuryV2.TreasuryPublic}>()
+						  ?? panic("A DAOTreasuryV2 doesn't exist here.")
 		  var _keyIds: [Int] = []
 	  
 		  for keyId in keyIds {
 			  _keyIds.append(Int(keyId))
 		  }
 	  
-		  self.messageSignaturePayload = MyMultiSig.MessageSignaturePayload(
+		  self.messageSignaturePayload = MyMultiSigV2.MessageSignaturePayload(
 			  _signingAddr: signer.address, _message: message, _keyIds: _keyIds, _signatures: signatures, _signatureBlock: signatureBlock
 		  )
 		}

--- a/packages/client/src/flow/getProposedActions.tx.js
+++ b/packages/client/src/flow/getProposedActions.tx.js
@@ -1,10 +1,10 @@
 export const GET_PROPOSED_ACTIONS = `
-	import DAOTreasury from 0xDAOTreasury
+	import DAOTreasuryV2 from 0xDAOTreasuryV2
 
 	pub fun main(treasuryAddr: Address): {UInt64: String} {
-		let treasury = getAccount(treasuryAddr).getCapability(DAOTreasury.TreasuryPublicPath)
-											.borrow<&DAOTreasury.Treasury{DAOTreasury.TreasuryPublic}>()
-											?? panic("A DAOTreasury doesn't exist here.")
+		let treasury = getAccount(treasuryAddr).getCapability(DAOTreasuryV2.TreasuryPublicPath)
+											.borrow<&DAOTreasuryV2.Treasury{DAOTreasuryV2.TreasuryPublic}>()
+											?? panic("A DAOTreasuryV2 doesn't exist here.")
 
 		return treasury.borrowManagerPublic().getIntents()
 	}

--- a/packages/client/src/flow/getSignersForAction.tx.js
+++ b/packages/client/src/flow/getSignersForAction.tx.js
@@ -1,10 +1,10 @@
 export const GET_SIGNERS_FOR_ACTION = `
-	import DAOTreasury from 0xDAOTreasury
+	import DAOTreasuryV2 from 0xDAOTreasuryV2
 
 	pub fun main(treasuryAddr: Address, actionUUID: UInt64): {Address: Bool} {
-		let treasury = getAccount(treasuryAddr).getCapability(DAOTreasury.TreasuryPublicPath)
-											.borrow<&DAOTreasury.Treasury{DAOTreasury.TreasuryPublic}>()
-											?? panic("A DAOTreasury doesn't exist here.")
+		let treasury = getAccount(treasuryAddr).getCapability(DAOTreasuryV2.TreasuryPublicPath)
+											.borrow<&DAOTreasuryV2.Treasury{DAOTreasuryV2.TreasuryPublic}>()
+											?? panic("A DAOTreasuryV2 doesn't exist here.")
 
 		return treasury.borrowManagerPublic().getVerifiedSignersForAction(actionUUID: actionUUID)
 	}

--- a/packages/client/src/flow/getTreasuryIdentifiers.tx.js
+++ b/packages/client/src/flow/getTreasuryIdentifiers.tx.js
@@ -1,10 +1,10 @@
 export const GET_TREASURY_IDENTIFIERS = `
-	import DAOTreasury from 0xDAOTreasury
+	import DAOTreasuryV2 from 0xDAOTreasuryV2
 
 	pub fun main(treasuryAddr: Address): [[String]] {
-		let treasury = getAccount(treasuryAddr).getCapability(DAOTreasury.TreasuryPublicPath)
-											.borrow<&DAOTreasury.Treasury{DAOTreasury.TreasuryPublic}>()
-											?? panic("A DAOTreasury doesn't exist here.")
+		let treasury = getAccount(treasuryAddr).getCapability(DAOTreasuryV2.TreasuryPublicPath)
+											.borrow<&DAOTreasuryV2.Treasury{DAOTreasuryV2.TreasuryPublic}>()
+											?? panic("A DAOTreasuryV2 doesn't exist here.")
 
 		let answer: [[String]] = []
 		answer.append(treasury.getVaultIdentifiers())

--- a/packages/client/src/flow/getVaultBalance.tx.js
+++ b/packages/client/src/flow/getVaultBalance.tx.js
@@ -1,11 +1,11 @@
 export const GET_VAULT_BALANCE = `
-	import DAOTreasury from 0xDAOTreasury
+	import DAOTreasuryV2 from 0xDAOTreasuryV2
 	import FungibleToken from 0xFungibleToken
 
 	pub fun main(treasuryAddr: Address, vaultId: String): UFix64 {
-		let treasury = getAccount(treasuryAddr).getCapability(DAOTreasury.TreasuryPublicPath)
-											.borrow<&DAOTreasury.Treasury{DAOTreasury.TreasuryPublic}>()
-											?? panic("A DAOTreasury doesn't exist here.")
+		let treasury = getAccount(treasuryAddr).getCapability(DAOTreasuryV2.TreasuryPublicPath)
+											.borrow<&DAOTreasuryV2.Treasury{DAOTreasuryV2.TreasuryPublic}>()
+											?? panic("A DAOTreasuryV2 doesn't exist here.")
 
 		let vault: &{FungibleToken.Balance} = treasury.borrowVaultPublic(identifier: vaultId)
 		return vault.balance

--- a/packages/client/src/flow/initializeTreasury.tx.js
+++ b/packages/client/src/flow/initializeTreasury.tx.js
@@ -1,11 +1,11 @@
 export const INITIALIZE_TREASURY = `
-	import DAOTreasury from 0xDAOTreasury
+	import DAOTreasuryV2 from 0xDAOTreasuryV2
 	import FlowToken from 0xFlowToken
 
 	transaction(initialSigners: [Address], initialThreshold: UInt64) {
   
 		prepare(signer: AuthAccount) {
-		  let treasury <- DAOTreasury.createTreasury(initialSigners: initialSigners, initialThreshold: initialThreshold)
+		  let treasury <- DAOTreasuryV2.createTreasury(initialSigners: initialSigners, initialThreshold: initialThreshold)
 	  
 		  // Seed Treasury with commonly used vaults
 		  let flowVault <- FlowToken.createEmptyVault()
@@ -13,8 +13,8 @@ export const INITIALIZE_TREASURY = `
 		  treasury.depositVault(vault: <- flowVault)
 	  
 		  // Save Treasury to the account
-		  signer.save(<- treasury, to: DAOTreasury.TreasuryStoragePath)
-		  signer.link<&DAOTreasury.Treasury{DAOTreasury.TreasuryPublic}>(DAOTreasury.TreasuryPublicPath, target: DAOTreasury.TreasuryStoragePath)
+		  signer.save(<- treasury, to: DAOTreasuryV2.TreasuryStoragePath)
+		  signer.link<&DAOTreasuryV2.Treasury{DAOTreasuryV2.TreasuryPublic}>(DAOTreasuryV2.TreasuryPublicPath, target: DAOTreasuryV2.TreasuryStoragePath)
 		}
 	  }
 `;

--- a/packages/client/src/flow/proposeNFTTransfer.tx.js
+++ b/packages/client/src/flow/proposeNFTTransfer.tx.js
@@ -4,21 +4,33 @@ export const PROPOSE_NFT_TRANSFER = `
 	import NonFungibleToken from 0xNonFungibleToken
 	import MyMultiSig from 0xMyMultiSig
 	import ExampleNFT from 0xExampleNFT
-
-	transaction(treasuryAddr: Address, recipientAddr: Address, id: UInt64) {
-
-		let Treasury: &DAOTreasury.Treasury{DAOTreasury.TreasuryPublic}
-		let RecipientCollection: Capability<&{NonFungibleToken.CollectionPublic}>
+	
+	transaction(treasuryAddr: Address, recipientAddr: Address, id: UInt64, message: String, keyIds: [UInt64], signatures: [String], signatureBlock: UInt64) {
+	
+	  let treasury: &DAOTreasury.Treasury{DAOTreasury.TreasuryPublic}
+	  let recipientCollection: Capability<&{NonFungibleToken.CollectionPublic}>
+	  let action: AnyStruct{MyMultiSig.Action}
+	  let messageSignaturePayload: MyMultiSig.MessageSignaturePayload
+	  
+	  prepare(signer: AuthAccount) {
+		self.treasury = getAccount(treasuryAddr).getCapability(DAOTreasury.TreasuryPublicPath)
+						.borrow<&DAOTreasury.Treasury{DAOTreasury.TreasuryPublic}>()
+						?? panic("A DAOTreasury doesn't exist here.")
+		self.recipientCollection = getAccount(recipientAddr).getCapability<&{NonFungibleToken.CollectionPublic}>(ExampleNFT.CollectionPublicPath)
+		self.action = TreasuryActions.TransferNFT(_recipientCollection: self.recipientCollection, _nftID: id, _proposer: signer.address)
 		
-		prepare(signer: AuthAccount) {
-			self.Treasury = getAccount(treasuryAddr).getCapability(DAOTreasury.TreasuryPublicPath)
-											.borrow<&DAOTreasury.Treasury{DAOTreasury.TreasuryPublic}>()
-											?? panic("A DAOTreasury doesn't exist here.")
-			self.RecipientCollection = getAccount(recipientAddr).getCapability<&{NonFungibleToken.CollectionPublic}>(ExampleNFT.CollectionPublicPath)
+		var _keyIds: [Int] = []
+	
+		for keyId in keyIds {
+			_keyIds.append(Int(keyId))
 		}
-		execute {
-			let action = TreasuryActions.TransferNFT(_recipientCollection: self.RecipientCollection, _nftID: id)
-			self.Treasury.proposeAction(action: action)
-		}
+	
+		self.messageSignaturePayload = MyMultiSig.MessageSignaturePayload(
+			_signingAddr: signer.address, _message: message, _keyIds: _keyIds, _signatures: signatures, _signatureBlock: signatureBlock
+		)
+	  }
+	  execute {
+		self.treasury.proposeAction(action: self.action, signaturePayload: self.messageSignaturePayload)
+	  }
 	}
 `;

--- a/packages/client/src/flow/proposeNFTTransfer.tx.js
+++ b/packages/client/src/flow/proposeNFTTransfer.tx.js
@@ -1,23 +1,23 @@
 export const PROPOSE_NFT_TRANSFER = `
-	import TreasuryActions from 0xTreasuryActions
-	import DAOTreasury from 0xDAOTreasury
+	import TreasuryActionsV2 from 0xTreasuryActionsV2
+	import DAOTreasuryV2 from 0xDAOTreasuryV2
 	import NonFungibleToken from 0xNonFungibleToken
-	import MyMultiSig from 0xMyMultiSig
+	import MyMultiSigV2 from 0xMyMultiSigV2
 	import ExampleNFT from 0xExampleNFT
 	
 	transaction(treasuryAddr: Address, recipientAddr: Address, id: UInt64, message: String, keyIds: [UInt64], signatures: [String], signatureBlock: UInt64) {
 	
-	  let treasury: &DAOTreasury.Treasury{DAOTreasury.TreasuryPublic}
+	  let treasury: &DAOTreasuryV2.Treasury{DAOTreasuryV2.TreasuryPublic}
 	  let recipientCollection: Capability<&{NonFungibleToken.CollectionPublic}>
-	  let action: AnyStruct{MyMultiSig.Action}
-	  let messageSignaturePayload: MyMultiSig.MessageSignaturePayload
+	  let action: AnyStruct{MyMultiSigV2.Action}
+	  let messageSignaturePayload: MyMultiSigV2.MessageSignaturePayload
 	  
 	  prepare(signer: AuthAccount) {
-		self.treasury = getAccount(treasuryAddr).getCapability(DAOTreasury.TreasuryPublicPath)
-						.borrow<&DAOTreasury.Treasury{DAOTreasury.TreasuryPublic}>()
-						?? panic("A DAOTreasury doesn't exist here.")
+		self.treasury = getAccount(treasuryAddr).getCapability(DAOTreasuryV2.TreasuryPublicPath)
+						.borrow<&DAOTreasuryV2.Treasury{DAOTreasuryV2.TreasuryPublic}>()
+						?? panic("A DAOTreasuryV2 doesn't exist here.")
 		self.recipientCollection = getAccount(recipientAddr).getCapability<&{NonFungibleToken.CollectionPublic}>(ExampleNFT.CollectionPublicPath)
-		self.action = TreasuryActions.TransferNFT(_recipientCollection: self.recipientCollection, _nftID: id, _proposer: signer.address)
+		self.action = TreasuryActionsV2.TransferNFT(_recipientCollection: self.recipientCollection, _nftID: id, _proposer: signer.address)
 		
 		var _keyIds: [Int] = []
 	
@@ -25,7 +25,7 @@ export const PROPOSE_NFT_TRANSFER = `
 			_keyIds.append(Int(keyId))
 		}
 	
-		self.messageSignaturePayload = MyMultiSig.MessageSignaturePayload(
+		self.messageSignaturePayload = MyMultiSigV2.MessageSignaturePayload(
 			_signingAddr: signer.address, _message: message, _keyIds: _keyIds, _signatures: signatures, _signatureBlock: signatureBlock
 		)
 	  }

--- a/packages/client/src/flow/proposeTransfer.tx.js
+++ b/packages/client/src/flow/proposeTransfer.tx.js
@@ -1,22 +1,22 @@
 export const PROPOSE_TRANSFER = `
-	import TreasuryActions from 0xTreasuryActions
-	import DAOTreasury from 0xDAOTreasury
+	import TreasuryActionsV2 from 0xTreasuryActionsV2
+	import DAOTreasuryV2 from 0xDAOTreasuryV2
 	import FungibleToken from 0xFungibleToken
-	import MyMultiSig from 0xMyMultiSig
+	import MyMultiSigV2 from 0xMyMultiSigV2
 	
 	transaction(treasuryAddr: Address, recipientAddr: Address, amount: UFix64, message: String, keyIds: [UInt64], signatures: [String], signatureBlock: UInt64) {
 	
-	  let treasury: &DAOTreasury.Treasury{DAOTreasury.TreasuryPublic}
+	  let treasury: &DAOTreasuryV2.Treasury{DAOTreasuryV2.TreasuryPublic}
 	  let recipientVault: Capability<&{FungibleToken.Receiver}>
-	  let action: AnyStruct{MyMultiSig.Action}
-	  let messageSignaturePayload: MyMultiSig.MessageSignaturePayload
+	  let action: AnyStruct{MyMultiSigV2.Action}
+	  let messageSignaturePayload: MyMultiSigV2.MessageSignaturePayload
 	  
 	  prepare(signer: AuthAccount) {
-		self.treasury = getAccount(treasuryAddr).getCapability(DAOTreasury.TreasuryPublicPath)
-						.borrow<&DAOTreasury.Treasury{DAOTreasury.TreasuryPublic}>()
-						?? panic("A DAOTreasury doesn't exist here.")
+		self.treasury = getAccount(treasuryAddr).getCapability(DAOTreasuryV2.TreasuryPublicPath)
+						.borrow<&DAOTreasuryV2.Treasury{DAOTreasuryV2.TreasuryPublic}>()
+						?? panic("A DAOTreasuryV2 doesn't exist here.")
 		self.recipientVault = getAccount(recipientAddr).getCapability<&{FungibleToken.Receiver}>(/public/flowTokenReceiver)
-		self.action = TreasuryActions.TransferToken(_recipientVault: self.recipientVault, _amount: amount, _proposer: signer.address)
+		self.action = TreasuryActionsV2.TransferToken(_recipientVault: self.recipientVault, _amount: amount, _proposer: signer.address)
 	
 		var _keyIds: [Int] = []
 	
@@ -24,7 +24,7 @@ export const PROPOSE_TRANSFER = `
 			_keyIds.append(Int(keyId))
 		}
 	
-		self.messageSignaturePayload = MyMultiSig.MessageSignaturePayload(
+		self.messageSignaturePayload = MyMultiSigV2.MessageSignaturePayload(
 			_signingAddr: signer.address, _message: message, _keyIds: _keyIds, _signatures: signatures, _signatureBlock: signatureBlock
 		)
 	  }

--- a/packages/client/src/flow/proposeTransfer.tx.js
+++ b/packages/client/src/flow/proposeTransfer.tx.js
@@ -3,21 +3,33 @@ export const PROPOSE_TRANSFER = `
 	import DAOTreasury from 0xDAOTreasury
 	import FungibleToken from 0xFungibleToken
 	import MyMultiSig from 0xMyMultiSig
-
-	transaction(treasuryAddr: Address, recipientAddr: Address, amount: UFix64) {
-
-		let Treasury: &DAOTreasury.Treasury{DAOTreasury.TreasuryPublic}
-		let RecipientVault: Capability<&{FungibleToken.Receiver}>
-		
-		prepare(signer: AuthAccount) {
-			self.Treasury = getAccount(treasuryAddr).getCapability(DAOTreasury.TreasuryPublicPath)
-											.borrow<&DAOTreasury.Treasury{DAOTreasury.TreasuryPublic}>()
-											?? panic("A DAOTreasury doesn't exist here.")
-			self.RecipientVault = getAccount(recipientAddr).getCapability<&{FungibleToken.Receiver}>(/public/flowTokenReceiver)
+	
+	transaction(treasuryAddr: Address, recipientAddr: Address, amount: UFix64, message: String, keyIds: [UInt64], signatures: [String], signatureBlock: UInt64) {
+	
+	  let treasury: &DAOTreasury.Treasury{DAOTreasury.TreasuryPublic}
+	  let recipientVault: Capability<&{FungibleToken.Receiver}>
+	  let action: AnyStruct{MyMultiSig.Action}
+	  let messageSignaturePayload: MyMultiSig.MessageSignaturePayload
+	  
+	  prepare(signer: AuthAccount) {
+		self.treasury = getAccount(treasuryAddr).getCapability(DAOTreasury.TreasuryPublicPath)
+						.borrow<&DAOTreasury.Treasury{DAOTreasury.TreasuryPublic}>()
+						?? panic("A DAOTreasury doesn't exist here.")
+		self.recipientVault = getAccount(recipientAddr).getCapability<&{FungibleToken.Receiver}>(/public/flowTokenReceiver)
+		self.action = TreasuryActions.TransferToken(_recipientVault: self.recipientVault, _amount: amount, _proposer: signer.address)
+	
+		var _keyIds: [Int] = []
+	
+		for keyId in keyIds {
+			_keyIds.append(Int(keyId))
 		}
-		execute {
-			let action = TreasuryActions.TransferToken(_recipientVault: self.RecipientVault, _amount: amount)
-			self.Treasury.proposeAction(action: action)
-		}
+	
+		self.messageSignaturePayload = MyMultiSig.MessageSignaturePayload(
+			_signingAddr: signer.address, _message: message, _keyIds: _keyIds, _signatures: signatures, _signatureBlock: signatureBlock
+		)
+	  }
+	  execute {
+		self.treasury.proposeAction(action: self.action, signaturePayload: self.messageSignaturePayload)
+	  }
 	}
 `;

--- a/packages/client/src/flow/removeSigner.tx.js
+++ b/packages/client/src/flow/removeSigner.tx.js
@@ -1,18 +1,30 @@
 export const REMOVE_SIGNER = `
 import DAOTreasury from 0xDAOTreasury
 import TreasuryActions from 0xTreasuryActions
+import MyMultiSig from 0xMyMultiSig
 
-transaction(signerToBeRemoved: Address) {
+transaction(signerToBeRemoved: Address, message: String, keyIds: [UInt64], signatures: [String], signatureBlock: UInt64) {
   
-  let Treasury: &DAOTreasury.Treasury{DAOTreasury.TreasuryPublic}
+  let treasury: &DAOTreasury.Treasury{DAOTreasury.TreasuryPublic}
+  let action: AnyStruct{MyMultiSig.Action}
+  let messageSignaturePayload: MyMultiSig.MessageSignaturePayload
 
   prepare(signer: AuthAccount) {
-    self.Treasury = signer.borrow<&DAOTreasury.Treasury>(from: DAOTreasury.TreasuryStoragePath)
+    self.treasury = signer.borrow<&DAOTreasury.Treasury>(from: DAOTreasury.TreasuryStoragePath)
                     ?? panic("Could not borrow the DAOTreasury")
+    self.action = TreasuryActions.RemoveSigner(signerToBeRemoved, signer.address)
+    var _keyIds: [Int] = []
+
+    for keyId in keyIds {
+        _keyIds.append(Int(keyId))
+    }
+
+    self.messageSignaturePayload = MyMultiSig.MessageSignaturePayload(
+        _signingAddr: signer.address, _message: message, _keyIds: _keyIds, _signatures: signatures, _signatureBlock: signatureBlock
+    )
   }
   execute {
-    let action = TreasuryActions.RemoveSigner(_signer: signerToBeRemoved)
-    self.Treasury.proposeAction(action: action)
+    self.treasury.proposeAction(action: self.action, signaturePayload: self.messageSignaturePayload)
   }
 }
 `;

--- a/packages/client/src/flow/removeSigner.tx.js
+++ b/packages/client/src/flow/removeSigner.tx.js
@@ -3,15 +3,16 @@ import DAOTreasury from 0xDAOTreasury
 import TreasuryActions from 0xTreasuryActions
 import MyMultiSig from 0xMyMultiSig
 
-transaction(signerToBeRemoved: Address, message: String, keyIds: [UInt64], signatures: [String], signatureBlock: UInt64) {
+transaction(treasuryAddr: Address, signerToBeRemoved: Address, message: String, keyIds: [UInt64], signatures: [String], signatureBlock: UInt64) {
   
   let treasury: &DAOTreasury.Treasury{DAOTreasury.TreasuryPublic}
   let action: AnyStruct{MyMultiSig.Action}
   let messageSignaturePayload: MyMultiSig.MessageSignaturePayload
 
   prepare(signer: AuthAccount) {
-    self.treasury = signer.borrow<&DAOTreasury.Treasury>(from: DAOTreasury.TreasuryStoragePath)
-                    ?? panic("Could not borrow the DAOTreasury")
+        self.treasury = getAccount(treasuryAddr).getCapability(DAOTreasury.TreasuryPublicPath)
+                    .borrow<&DAOTreasury.Treasury{DAOTreasury.TreasuryPublic}>()
+                    ?? panic("A DAOTreasury doesn't exist here.")
     self.action = TreasuryActions.RemoveSigner(signerToBeRemoved, signer.address)
     var _keyIds: [Int] = []
 

--- a/packages/client/src/flow/removeSigner.tx.js
+++ b/packages/client/src/flow/removeSigner.tx.js
@@ -1,26 +1,26 @@
 export const REMOVE_SIGNER = `
-import DAOTreasury from 0xDAOTreasury
-import TreasuryActions from 0xTreasuryActions
-import MyMultiSig from 0xMyMultiSig
+import DAOTreasuryV2 from 0xDAOTreasuryV2
+import TreasuryActionsV2 from 0xTreasuryActionsV2
+import MyMultiSigV2 from 0xMyMultiSigV2
 
 transaction(treasuryAddr: Address, signerToBeRemoved: Address, message: String, keyIds: [UInt64], signatures: [String], signatureBlock: UInt64) {
   
-  let treasury: &DAOTreasury.Treasury{DAOTreasury.TreasuryPublic}
-  let action: AnyStruct{MyMultiSig.Action}
-  let messageSignaturePayload: MyMultiSig.MessageSignaturePayload
+  let treasury: &DAOTreasuryV2.Treasury{DAOTreasuryV2.TreasuryPublic}
+  let action: AnyStruct{MyMultiSigV2.Action}
+  let messageSignaturePayload: MyMultiSigV2.MessageSignaturePayload
 
   prepare(signer: AuthAccount) {
-        self.treasury = getAccount(treasuryAddr).getCapability(DAOTreasury.TreasuryPublicPath)
-                    .borrow<&DAOTreasury.Treasury{DAOTreasury.TreasuryPublic}>()
-                    ?? panic("A DAOTreasury doesn't exist here.")
-    self.action = TreasuryActions.RemoveSigner(_signer: signerToBeRemoved, _proposer: signer.address)
+        self.treasury = getAccount(treasuryAddr).getCapability(DAOTreasuryV2.TreasuryPublicPath)
+                    .borrow<&DAOTreasuryV2.Treasury{DAOTreasuryV2.TreasuryPublic}>()
+                    ?? panic("A DAOTreasuryV2 doesn't exist here.")
+    self.action = TreasuryActionsV2.RemoveSigner(_signer: signerToBeRemoved, _proposer: signer.address)
     var _keyIds: [Int] = []
 
     for keyId in keyIds {
         _keyIds.append(Int(keyId))
     }
 
-    self.messageSignaturePayload = MyMultiSig.MessageSignaturePayload(
+    self.messageSignaturePayload = MyMultiSigV2.MessageSignaturePayload(
         _signingAddr: signer.address, _message: message, _keyIds: _keyIds, _signatures: signatures, _signatureBlock: signatureBlock
     )
   }

--- a/packages/client/src/flow/sendCollectionToTreasury.tx.js
+++ b/packages/client/src/flow/sendCollectionToTreasury.tx.js
@@ -1,8 +1,8 @@
 export const SEND_COLLECTION_TO_TREASURY = `
 	import NonFungibleToken from 0xNonFungibleToken
 	import ExampleNFT from 0xExampleNFT
-	import DAOTreasury from 0xDAOTreasury
-	import MyMultiSig from 0xMyMultiSig
+	import DAOTreasuryV2 from 0xDAOTreasuryV2
+	import MyMultiSigV2 from 0xMyMultiSigV2
 
 	transaction(treasuryAddr: Address, message: String, keyIds: [UInt64], signatures: [String], signatureBlock: UInt64) {
 
@@ -13,9 +13,9 @@ export const SEND_COLLECTION_TO_TREASURY = `
 				.borrow<&ExampleNFT.Collection>(from: ExampleNFT.CollectionStoragePath)
 				?? panic("Could not borrow a reference to the owner's collection")
 	
-			let treasury = getAccount(treasuryAddr).getCapability(DAOTreasury.TreasuryPublicPath)
-						.borrow<&DAOTreasury.Treasury{DAOTreasury.TreasuryPublic}>()
-						?? panic("A DAOTreasury doesn't exist here.")
+			let treasury = getAccount(treasuryAddr).getCapability(DAOTreasuryV2.TreasuryPublicPath)
+						.borrow<&DAOTreasuryV2.Treasury{DAOTreasuryV2.TreasuryPublic}>()
+						?? panic("A DAOTreasuryV2 doesn't exist here.")
 	
 			let collection <- ExampleNFT.createEmptyCollection()
 	
@@ -25,7 +25,7 @@ export const SEND_COLLECTION_TO_TREASURY = `
 				_keyIds.append(Int(keyId))
 			}
 	
-			let messageSignaturePayload = MyMultiSig.MessageSignaturePayload(
+			let messageSignaturePayload = MyMultiSigV2.MessageSignaturePayload(
 				_signingAddr: signer.address, _message: message, _keyIds: _keyIds, _signatures: signatures, _signatureBlock: signatureBlock
 			)
 			// Deposit the NFT in the treasury's collection

--- a/packages/client/src/flow/sendFlowToTreasury.tx.js
+++ b/packages/client/src/flow/sendFlowToTreasury.tx.js
@@ -1,5 +1,5 @@
 export const SEND_FLOW_TO_TREASURY = `
-	import DAOTreasury from 0xDAOTreasury
+	import DAOTreasuryV2 from 0xDAOTreasuryV2
 	import FungibleToken from 0xFungibleToken
 
 	transaction(treasuryAddr: Address, amount: UFix64) {
@@ -9,9 +9,9 @@ export const SEND_FLOW_TO_TREASURY = `
 			let vault = signer.borrow<&FungibleToken.Vault>(from: /storage/flowTokenVault)!
 			let tokens <- vault.withdraw(amount: amount)
 		
-			let treasury = getAccount(treasuryAddr).getCapability(DAOTreasury.TreasuryPublicPath)
-						.borrow<&DAOTreasury.Treasury{DAOTreasury.TreasuryPublic}>()
-						?? panic("A DAOTreasury doesn't exist here.")
+			let treasury = getAccount(treasuryAddr).getCapability(DAOTreasuryV2.TreasuryPublicPath)
+						.borrow<&DAOTreasuryV2.Treasury{DAOTreasuryV2.TreasuryPublic}>()
+						?? panic("A DAOTreasuryV2 doesn't exist here.")
 		
 			let identifier: String = vault.getType().identifier
 		

--- a/packages/client/src/flow/sendNFTToTreasury.tx.js
+++ b/packages/client/src/flow/sendNFTToTreasury.tx.js
@@ -1,8 +1,8 @@
 export const SEND_NFT_TO_TREASURY = `
 	import NonFungibleToken from 0xNonFungibleToken
 	import ExampleNFT from 0xExampleNFT
-	import DAOTreasury from 0xDAOTreasury
-	import MyMultiSig from 0xMyMultiSig
+	import DAOTreasuryV2 from 0xDAOTreasuryV2
+	import MyMultiSigV2 from 0xMyMultiSigV2
 
 	transaction(treasuryAddr: Address, withdrawID: UInt64) {
 
@@ -12,9 +12,9 @@ export const SEND_NFT_TO_TREASURY = `
 							.borrow<&ExampleNFT.Collection>(from: ExampleNFT.CollectionStoragePath)
 							?? panic("Could not borrow a reference to the owner's collection")
 
-					let treasury = getAccount(treasuryAddr).getCapability(DAOTreasury.TreasuryPublicPath)
-											.borrow<&DAOTreasury.Treasury{DAOTreasury.TreasuryPublic}>()
-											?? panic("A DAOTreasury doesn't exist here.")
+					let treasury = getAccount(treasuryAddr).getCapability(DAOTreasuryV2.TreasuryPublicPath)
+											.borrow<&DAOTreasuryV2.Treasury{DAOTreasuryV2.TreasuryPublic}>()
+											?? panic("A DAOTreasuryV2 doesn't exist here.")
 
 					// withdraw the NFT from the owner's collection
 					let nft <- collectionRef.withdraw(withdrawID: withdrawID)

--- a/packages/client/src/flow/signerApprove.tx.js
+++ b/packages/client/src/flow/signerApprove.tx.js
@@ -1,18 +1,18 @@
 export const SIGNER_APPROVE = `
-	import DAOTreasury from 0xDAOTreasury
-	import MyMultiSig from 0xMyMultiSig
+	import DAOTreasuryV2 from 0xDAOTreasuryV2
+	import MyMultiSigV2 from 0xMyMultiSigV2
 
 	transaction(treasuryAddr: Address, actionUUID: UInt64, message: String, keyIds: [UInt64], signatures: [String], signatureBlock: UInt64) {
 
 		var isValid: Bool
-		let action: &MyMultiSig.MultiSignAction 
-		let messageSignaturePayload: MyMultiSig.MessageSignaturePayload
+		let action: &MyMultiSigV2.MultiSignAction 
+		let messageSignaturePayload: MyMultiSigV2.MessageSignaturePayload
 	  
 		prepare(signer: AuthAccount) {
 		  self.isValid = false
-		  let treasury = getAccount(treasuryAddr).getCapability(DAOTreasury.TreasuryPublicPath)
-						  .borrow<&DAOTreasury.Treasury{DAOTreasury.TreasuryPublic}>()
-						  ?? panic("A DAOTreasury doesn't exist here.")
+		  let treasury = getAccount(treasuryAddr).getCapability(DAOTreasuryV2.TreasuryPublicPath)
+						  .borrow<&DAOTreasuryV2.Treasury{DAOTreasuryV2.TreasuryPublic}>()
+						  ?? panic("A DAOTreasuryV2 doesn't exist here.")
 	  
 		  let manager = treasury.borrowManagerPublic()
 		  self.action = manager.borrowAction(actionUUID: actionUUID)
@@ -23,7 +23,7 @@ export const SIGNER_APPROVE = `
 			_keyIds.append(Int(keyId))
 		  }
 	  
-		  self.messageSignaturePayload = MyMultiSig.MessageSignaturePayload(
+		  self.messageSignaturePayload = MyMultiSigV2.MessageSignaturePayload(
 			_signingAddr: signer.address, _message: message, _keyIds: _keyIds, _signatures: signatures, _signatureBlock: signatureBlock
 		  )
 	  

--- a/packages/client/src/flow/updateSigner.tx.js
+++ b/packages/client/src/flow/updateSigner.tx.js
@@ -1,11 +1,11 @@
 export const UPDATE_SIGNER = `
-  import DAOTreasury from 0xDAOTreasury
+  import DAOTreasuryV2 from 0xDAOTreasuryV2
 
   transaction(oldSignerAddress: Address, newSignerAddress: Address) {
 
     prepare(signer: AuthAccount) {
-      let treasury = signer.borrow<&DAOTreasury.Treasury>(from: DAOTreasury.TreasuryStoragePath)
-                      ?? panic("Could not borrow the DAOTreasury")
+      let treasury = signer.borrow<&DAOTreasuryV2.Treasury>(from: DAOTreasuryV2.TreasuryStoragePath)
+                      ?? panic("Could not borrow the DAOTreasuryV2")
       let manager = treasury.borrowManager()
 
       manager.removeSigner(signer: oldSignerAddress)

--- a/packages/client/src/flow/updateThreshold.tx.js
+++ b/packages/client/src/flow/updateThreshold.tx.js
@@ -3,15 +3,16 @@ export const UPDATE_THRESHOLD = `
   import TreasuryActions from 0xTreasuryActions
   import MyMultiSig from 0xMyMultiSig
 
-  transaction(newThreshold: UInt64, message: String, keyIds: [UInt64], signatures: [String], signatureBlock: UInt64) {
-    
+  transaction(treasuryAddr: Address, newThreshold: UInt64, message: String, keyIds: [UInt64], signatures: [String], signatureBlock: UInt64) {
+  
     let treasury: &DAOTreasury.Treasury{DAOTreasury.TreasuryPublic}
     let action: AnyStruct{MyMultiSig.Action}
     let messageSignaturePayload: MyMultiSig.MessageSignaturePayload
   
     prepare(signer: AuthAccount) {
-      self.treasury = signer.borrow<&DAOTreasury.Treasury>(from: DAOTreasury.TreasuryStoragePath)
-                      ?? panic("Could not borrow the DAOTreasury")
+          self.treasury = getAccount(treasuryAddr).getCapability(DAOTreasury.TreasuryPublicPath)
+                      .borrow<&DAOTreasury.Treasury{DAOTreasury.TreasuryPublic}>()
+                      ?? panic("A DAOTreasury doesn't exist here.")
       self.action = TreasuryActions.UpdateThreshold(newThreshold, signer.address)
   
       var _keyIds: [Int] = []

--- a/packages/client/src/flow/updateThreshold.tx.js
+++ b/packages/client/src/flow/updateThreshold.tx.js
@@ -1,19 +1,19 @@
 export const UPDATE_THRESHOLD = `
-	import DAOTreasury from 0xDAOTreasury
-  import TreasuryActions from 0xTreasuryActions
-  import MyMultiSig from 0xMyMultiSig
+	import DAOTreasuryV2 from 0xDAOTreasuryV2
+  import TreasuryActionsV2 from 0xTreasuryActionsV2
+  import MyMultiSigV2 from 0xMyMultiSigV2
 
   transaction(treasuryAddr: Address, newThreshold: UInt64, message: String, keyIds: [UInt64], signatures: [String], signatureBlock: UInt64) {
   
-    let treasury: &DAOTreasury.Treasury{DAOTreasury.TreasuryPublic}
-    let action: AnyStruct{MyMultiSig.Action}
-    let messageSignaturePayload: MyMultiSig.MessageSignaturePayload
+    let treasury: &DAOTreasuryV2.Treasury{DAOTreasuryV2.TreasuryPublic}
+    let action: AnyStruct{MyMultiSigV2.Action}
+    let messageSignaturePayload: MyMultiSigV2.MessageSignaturePayload
   
     prepare(signer: AuthAccount) {
-          self.treasury = getAccount(treasuryAddr).getCapability(DAOTreasury.TreasuryPublicPath)
-                      .borrow<&DAOTreasury.Treasury{DAOTreasury.TreasuryPublic}>()
-                      ?? panic("A DAOTreasury doesn't exist here.")
-      self.action = TreasuryActions.UpdateThreshold(_threshold: newThreshold, _proposer: signer.address)
+          self.treasury = getAccount(treasuryAddr).getCapability(DAOTreasuryV2.TreasuryPublicPath)
+                      .borrow<&DAOTreasuryV2.Treasury{DAOTreasuryV2.TreasuryPublic}>()
+                      ?? panic("A DAOTreasuryV2 doesn't exist here.")
+      self.action = TreasuryActionsV2.UpdateThreshold(_threshold: newThreshold, _proposer: signer.address)
   
       var _keyIds: [Int] = []
   
@@ -21,7 +21,7 @@ export const UPDATE_THRESHOLD = `
           _keyIds.append(Int(keyId))
       }
   
-      self.messageSignaturePayload = MyMultiSig.MessageSignaturePayload(
+      self.messageSignaturePayload = MyMultiSigV2.MessageSignaturePayload(
           _signingAddr: signer.address, _message: message, _keyIds: _keyIds, _signatures: signatures, _signatureBlock: signatureBlock
       )
     }

--- a/packages/client/src/flow/updateThreshold.tx.js
+++ b/packages/client/src/flow/updateThreshold.tx.js
@@ -1,18 +1,31 @@
 export const UPDATE_THRESHOLD = `
 	import DAOTreasury from 0xDAOTreasury
   import TreasuryActions from 0xTreasuryActions
+  import MyMultiSig from 0xMyMultiSig
 
-	transaction(newThreshold: UInt64) {
-  
-    let Treasury: &DAOTreasury.Treasury{DAOTreasury.TreasuryPublic}
+  transaction(newThreshold: UInt64, message: String, keyIds: [UInt64], signatures: [String], signatureBlock: UInt64) {
+    
+    let treasury: &DAOTreasury.Treasury{DAOTreasury.TreasuryPublic}
+    let action: AnyStruct{MyMultiSig.Action}
+    let messageSignaturePayload: MyMultiSig.MessageSignaturePayload
   
     prepare(signer: AuthAccount) {
-      self.Treasury = signer.borrow<&DAOTreasury.Treasury>(from: DAOTreasury.TreasuryStoragePath)
+      self.treasury = signer.borrow<&DAOTreasury.Treasury>(from: DAOTreasury.TreasuryStoragePath)
                       ?? panic("Could not borrow the DAOTreasury")
+      self.action = TreasuryActions.UpdateThreshold(newThreshold, signer.address)
+  
+      var _keyIds: [Int] = []
+  
+      for keyId in keyIds {
+          _keyIds.append(Int(keyId))
+      }
+  
+      self.messageSignaturePayload = MyMultiSig.MessageSignaturePayload(
+          _signingAddr: signer.address, _message: message, _keyIds: _keyIds, _signatures: signatures, _signatureBlock: signatureBlock
+      )
     }
     execute {
-      let action = TreasuryActions.UpdateThreshold(_threshold: newThreshold)
-      self.Treasury.proposeAction(action: action)
+      self.treasury.proposeAction(action: self.action, signaturePayload: self.messageSignaturePayload)
     }
   }
 `;

--- a/packages/client/src/hooks/useNFTs.js
+++ b/packages/client/src/hooks/useNFTs.js
@@ -1,6 +1,7 @@
 import { useEffect, useReducer } from "react";
 import { mutate, query, tx } from "@onflow/fcl";
 import reducer, { INITIAL_STATE } from "../reducers/nfts";
+import { REGULAR_LIMIT, SIGNED_LIMIT, EXECUTE_ACTION_LIMIT, createSignature } from "../contexts/Web3";
 import {
   CHECK_TREASURY_NFT_COLLECTION,
   PROPOSE_NFT_TRANSFER,
@@ -18,7 +19,7 @@ const doSendNFTToTreasury = async (treasuryAddr, tokenId) => {
       arg(treasuryAddr, t.Address),
       arg(parseInt(tokenId), t.UInt64),
     ],
-    limit: 55,
+    limit: REGULAR_LIMIT,
   });
 };
 
@@ -38,19 +39,31 @@ const doSendCollectionToTreasury = async (
       arg(signatures, t.Array(t.String)),
       arg(height, t.UInt64),
     ],
-    limit: 350,
+    limit: EXECUTE_ACTION_LIMIT,
   });
 };
 
-const doProposeNFTTransfer = async (treasuryAddr, recipient, tokenId) => {
+const doProposeNFTTransfer = async (
+  treasuryAddr,
+  recipient,
+  tokenId,
+  message,
+  keyIds,
+  signatures,
+  height
+) => {
   return await mutate({
     cadence: PROPOSE_NFT_TRANSFER,
     args: (arg, t) => [
       arg(treasuryAddr, t.Address),
       arg(recipient, t.Address),
       arg(parseInt(tokenId), t.UInt64),
+      arg(message, t.String),
+      arg(keyIds, t.Array(t.UInt64)),
+      arg(signatures, t.Array(t.String)),
+      arg(height, t.UInt64)
     ],
-    limit: 55,
+    limit: SIGNED_LIMIT,
   });
 };
 
@@ -133,9 +146,26 @@ export default function useNFTs() {
     return res;
   };
 
-  const proposeNFTTransfer = async (treasuryAddr, recipient, selectedNFT) => {
+  const proposeNFTTransfer = async (
+    treasuryAddr,
+    recipient,
+    selectedNFT
+  ) => {
+    const treasuryVault = `Capability<&AnyResource{A.${treasuryAddr.replace("0x", "")}.NonFungibleToken.CollectionPublic}>`;
+    const intent = `Transfer a ${treasuryVault} NFT from the treasury to ${recipient}`;
+
+    const { message, keyIds, signatures, height } = await createSignature(intent);
+
     const tokenId = selectedNFT.split("-")[1];
-    const res = await doProposeNFTTransfer(treasuryAddr, recipient, tokenId);
+    const res = await doProposeNFTTransfer(
+      treasuryAddr,
+      recipient,
+      tokenId,
+      message,
+      keyIds,
+      signatures,
+      height
+    );
     await tx(res).onceSealed();
     return res;
   };

--- a/packages/client/src/hooks/useTreasury.js
+++ b/packages/client/src/hooks/useTreasury.js
@@ -4,6 +4,15 @@ import { syncSafeOwnersWithSigners } from "../utils";
 
 import reducer, { INITIAL_STATE } from "../reducers/treasuries";
 import {
+  CREATE_TREASURY_LIMIT,
+  EXECUTE_ACTION_LIMIT,
+  REGULAR_LIMIT,
+  SIGNED_LIMIT,
+  SIGNER_APPROVE_LIMIT,
+  UPDATE_SIGNER_LIMIT,
+  createSignature
+} from "../contexts/Web3";
+import {
   GET_SIGNERS,
   GET_THRESHOLD,
   INITIALIZE_TREASURY,
@@ -39,7 +48,7 @@ const doCreateTreasury = async (signerAddresses, threshold) => {
       arg(signerAddresses, t.Array(t.Address)),
       arg(threshold, t.UInt64),
     ],
-    limit: 80,
+    limit: CREATE_TREASURY_LIMIT,
   });
 };
 
@@ -47,19 +56,34 @@ const doSendFlowToTreasury = async (treasuryAddr, amount) => {
   return await mutate({
     cadence: SEND_FLOW_TO_TREASURY,
     args: (arg, t) => [arg(treasuryAddr, t.Address), arg(amount, t.UFix64)],
-    limit: 55,
+    limit: REGULAR_LIMIT,
   });
 };
 
-const doProposeTransfer = async (treasuryAddr, recipientAddr, amount) => {
+const doProposeTransfer = async (
+  treasuryAddr,
+  recipientAddr,
+  amount
+) => {
+  const uFixAmount = String(parseFloat(amount).toFixed(8));
+  const tokenAddress = process.env.REACT_APP_FLOW_ENV === "emulator" ? "ee82856bf20e2aa6" : "9a0766d93b6608b7";
+  const recepientVault = `Capability<&AnyResource{A.${tokenAddress}.FungibleToken.Receiver}>`;
+  const intent = `Transfer ${uFixAmount} ${recepientVault} tokens from the treasury to ${recipientAddr}`;
+
+  const { message, keyIds, signatures, height } = await createSignature(intent);
+
   return await mutate({
     cadence: PROPOSE_TRANSFER,
     args: (arg, t) => [
       arg(treasuryAddr, t.Address),
       arg(recipientAddr, t.Address),
       arg(amount, t.UFix64),
+      arg(message, t.String),
+      arg(keyIds, t.Array(t.UInt64)),
+      arg(signatures, t.Array(t.String)),
+      arg(height, t.UInt64),
     ],
-    limit: 55,
+    limit: SIGNED_LIMIT,
   });
 };
 
@@ -81,31 +105,58 @@ const doSignApprove = async (
       arg(signatures, t.Array(t.String)),
       arg(signatureBlock, t.UInt64),
     ],
-    limit: 310,
+    limit: SIGNER_APPROVE_LIMIT,
   });
 };
 
 const doExecuteAction = async (treasuryAddr, actionUUID) => {
+  const { message, keyIds, signatures, height } = await createSignature(actionUUID.toString());
+
   return await mutate({
     cadence: EXECUTE_ACTION,
-    args: (arg, t) => [arg(treasuryAddr, t.Address), arg(actionUUID, t.UInt64)],
-    limit: 110,
+    args: (arg, t) => [
+      arg(treasuryAddr, t.Address),
+      arg(actionUUID, t.UInt64),
+      arg(message, t.String),
+      arg(keyIds, t.Array(t.UInt64)),
+      arg(signatures, t.Array(t.String)),
+      arg(height, t.UInt64)
+    ],
+    limit: EXECUTE_ACTION_LIMIT,
   });
 };
 
 const doUpdateThreshold = async (newThreshold) => {
+  const intent = `Update the threshold of signers to ${newThreshold}.`;
+  const { message, keyIds, signatures, height } = await createSignature(intent);
+
   return await mutate({
     cadence: UPDATE_THRESHOLD,
-    args: (arg, t) => [arg(newThreshold, t.UInt64)],
-    limit: 55,
+    args: (arg, t) => [
+      arg(newThreshold, t.UInt64),
+      arg(message, t.String),
+      arg(keyIds, t.Array(t.UInt64)),
+      arg(signatures, t.Array(t.String)),
+      arg(height, t.UInt64)
+    ],
+    limit: SIGNED_LIMIT,
   });
 };
 
 const doProposeAddSigner = async (newSignerAddress) => {
+  const intent = `Add account ${newSignerAddress} as a signer.`;
+  const { message, keyIds, signatures, height } = await createSignature(intent);
+
   return await mutate({
     cadence: ADD_SIGNER,
-    args: (arg, t) => [arg(newSignerAddress, t.Address)],
-    limit: 55,
+    args: (arg, t) => [
+      arg(newSignerAddress, t.Address),
+      arg(message, t.String),
+      arg(keyIds, t.Array(t.UInt64)),
+      arg(signatures, t.Array(t.String)),
+      arg(height, t.UInt64)
+    ],
+    limit: SIGNED_LIMIT,
   });
 };
 
@@ -116,15 +167,24 @@ const doUpdateSigner = async (oldSignerAddress, newSignerAddress) => {
       arg(oldSignerAddress, t.Address),
       arg(newSignerAddress, t.Address),
     ],
-    limit: 110,
+    limit: UPDATE_SIGNER_LIMIT,
   });
 };
 
 const doProposeRemoveSigner = async (signerToBeRemovedAddress) => {
+  const intent = `Remove ${signerToBeRemovedAddress} as a signer.`;
+  const { message, keyIds, signatures, height } = await createSignature(intent);
+
   return await mutate({
     cadence: REMOVE_SIGNER,
-    args: (arg, t) => [arg(signerToBeRemovedAddress, t.Address)],
-    limit: 110,
+    args: (arg, t) => [
+      arg(signerToBeRemovedAddress, t.Address),
+      arg(message, t.String),
+      arg(keyIds, t.Array(t.UInt64)),
+      arg(signatures, t.Array(t.String)),
+      arg(height, t.UInt64)
+    ],
+    limit: SIGNED_LIMIT,
   });
 };
 
@@ -276,6 +336,7 @@ export default function useTreasury(treasuryAddr) {
       },
     });
   };
+
   const fetchTreasury = async (treasuryAddr) => {
     const signers = await getSigners(treasuryAddr);
     if (signers) {
@@ -299,7 +360,7 @@ export default function useTreasury(treasuryAddr) {
     const res = await doProposeTransfer(
       treasuryAddr,
       recipientAddr,
-      String(parseFloat(amount).toFixed(8))
+      parseFloat(amount).toFixed(8)
     );
     await tx(res).onceSealed();
   };
@@ -353,6 +414,7 @@ export default function useTreasury(treasuryAddr) {
     await tx(res).onceSealed();
     await refreshTreasury();
   };
+
   return {
     ...state,
     refreshTreasury,

--- a/packages/client/src/hooks/useTreasury.js
+++ b/packages/client/src/hooks/useTreasury.js
@@ -126,13 +126,14 @@ const doExecuteAction = async (treasuryAddr, actionUUID) => {
   });
 };
 
-const doUpdateThreshold = async (newThreshold) => {
+const doUpdateThreshold = async (treasuryAddr, newThreshold) => {
   const intent = `Update the threshold of signers to ${newThreshold}.`;
   const { message, keyIds, signatures, height } = await createSignature(intent);
 
   return await mutate({
     cadence: UPDATE_THRESHOLD,
     args: (arg, t) => [
+      arg(treasuryAddr, t.Address),
       arg(newThreshold, t.UInt64),
       arg(message, t.String),
       arg(keyIds, t.Array(t.UInt64)),
@@ -143,13 +144,14 @@ const doUpdateThreshold = async (newThreshold) => {
   });
 };
 
-const doProposeAddSigner = async (newSignerAddress) => {
+const doProposeAddSigner = async (treasuryAddr, newSignerAddress) => {
   const intent = `Add account ${newSignerAddress} as a signer.`;
   const { message, keyIds, signatures, height } = await createSignature(intent);
 
   return await mutate({
     cadence: ADD_SIGNER,
     args: (arg, t) => [
+      arg(treasuryAddr, t.Address),
       arg(newSignerAddress, t.Address),
       arg(message, t.String),
       arg(keyIds, t.Array(t.UInt64)),
@@ -171,13 +173,14 @@ const doUpdateSigner = async (oldSignerAddress, newSignerAddress) => {
   });
 };
 
-const doProposeRemoveSigner = async (signerToBeRemovedAddress) => {
+const doProposeRemoveSigner = async (treasuryAddr, signerToBeRemovedAddress) => {
   const intent = `Remove ${signerToBeRemovedAddress} as a signer.`;
   const { message, keyIds, signatures, height } = await createSignature(intent);
 
   return await mutate({
     cadence: REMOVE_SIGNER,
     args: (arg, t) => [
+      arg(treasuryAddr, t.Address),
       arg(signerToBeRemovedAddress, t.Address),
       arg(message, t.String),
       arg(keyIds, t.Array(t.UInt64)),
@@ -392,13 +395,13 @@ export default function useTreasury(treasuryAddr) {
   };
 
   const updateThreshold = async (newThreshold) => {
-    const res = await doUpdateThreshold(newThreshold);
+    const res = await doUpdateThreshold(treasuryAddr, newThreshold);
     await tx(res).onceSealed();
     await refreshTreasury();
   };
 
   const proposeAddSigner = async (newSignerAddress) => {
-    const res = await doProposeAddSigner(newSignerAddress);
+    const res = await doProposeAddSigner(treasuryAddr, newSignerAddress);
     await tx(res).onceSealed();
     await refreshTreasury();
   };
@@ -410,7 +413,7 @@ export default function useTreasury(treasuryAddr) {
   };
 
   const proposeRemoveSigner = async (signerToBeRemovedAddress) => {
-    const res = await doProposeRemoveSigner(signerToBeRemovedAddress);
+    const res = await doProposeRemoveSigner(treasuryAddr, signerToBeRemovedAddress);
     await tx(res).onceSealed();
     await refreshTreasury();
   };

--- a/packages/client/src/pages/Safe.js
+++ b/packages/client/src/pages/Safe.js
@@ -136,7 +136,7 @@ function Safe({ web3 }) {
   };
 
   const onConfirmAction = async ({ uuid }) => {
-    await executeAction(parseInt(uuid, 10));
+    await executeAction(uuid);
   };
 
   const onDeposit = async () => {

--- a/packages/client/src/utils.js
+++ b/packages/client/src/utils.js
@@ -83,9 +83,8 @@ export const getProgressPercentageForSignersAmount = (signersAmount) => {
 };
 
 export const getFlowscanUrlForTransaction = (hash) => {
-  return `https://${
-    process.env.REACT_APP_FLOW_ENV === "mainnet" ? "" : "testnet."
-  }flowscan.org/transaction/${hash}`;
+  return `https://${process.env.REACT_APP_FLOW_ENV === "mainnet" ? "" : "testnet."
+    }flowscan.org/transaction/${hash}`;
 };
 
 export const syncSafeOwnersWithSigners = (signers, safeOwners) => {

--- a/scripts/get_intent.cdc
+++ b/scripts/get_intent.cdc
@@ -1,9 +1,9 @@
-import DAOTreasury from "../contracts/DAOTreasury.cdc"
+import DAOTreasuryV2 from "../contracts/DAOTreasury.cdc"
 
 pub fun main(treasuryAddr: Address, actionUUID: UInt64): String {
-  let treasury = getAccount(treasuryAddr).getCapability(DAOTreasury.TreasuryPublicPath)
-                    .borrow<&DAOTreasury.Treasury{DAOTreasury.TreasuryPublic}>()
-                    ?? panic("A DAOTreasury doesn't exist here.")
+  let treasury = getAccount(treasuryAddr).getCapability(DAOTreasuryV2.TreasuryPublicPath)
+                    .borrow<&DAOTreasuryV2.Treasury{DAOTreasuryV2.TreasuryPublic}>()
+                    ?? panic("A DAOTreasuryV2 doesn't exist here.")
 
   let manager = treasury.borrowManagerPublic()
   let action = manager.borrowAction(actionUUID: actionUUID)

--- a/scripts/get_proposed_actions.cdc
+++ b/scripts/get_proposed_actions.cdc
@@ -1,9 +1,9 @@
-import DAOTreasury from "../contracts/DAOTreasury.cdc"
+import DAOTreasuryV2 from "../contracts/DAOTreasury.cdc"
 
 pub fun main(treasuryAddr: Address): {UInt64: String} {
-  let treasury = getAccount(treasuryAddr).getCapability(DAOTreasury.TreasuryPublicPath)
-                    .borrow<&DAOTreasury.Treasury{DAOTreasury.TreasuryPublic}>()
-                    ?? panic("A DAOTreasury doesn't exist here.")
+  let treasury = getAccount(treasuryAddr).getCapability(DAOTreasuryV2.TreasuryPublicPath)
+                    .borrow<&DAOTreasuryV2.Treasury{DAOTreasuryV2.TreasuryPublic}>()
+                    ?? panic("A DAOTreasuryV2 doesn't exist here.")
 
   return treasury.borrowManagerPublic().getIntents()
 }

--- a/scripts/get_total_verified_for_action.cdc
+++ b/scripts/get_total_verified_for_action.cdc
@@ -1,9 +1,9 @@
-import DAOTreasury from "../contracts/DAOTreasury.cdc"
+import DAOTreasuryV2 from "../contracts/DAOTreasury.cdc"
 
 pub fun main(treasuryAddr: Address, actionUUID: UInt64): UInt64 {
-  let treasury = getAccount(treasuryAddr).getCapability(DAOTreasury.TreasuryPublicPath)
-                    .borrow<&DAOTreasury.Treasury{DAOTreasury.TreasuryPublic}>()
-                    ?? panic("A DAOTreasury doesn't exist here.")
+  let treasury = getAccount(treasuryAddr).getCapability(DAOTreasuryV2.TreasuryPublicPath)
+                    .borrow<&DAOTreasuryV2.Treasury{DAOTreasuryV2.TreasuryPublic}>()
+                    ?? panic("A DAOTreasuryV2 doesn't exist here.")
 
   return treasury.borrowManagerPublic().getTotalVerifiedForAction(actionUUID: actionUUID)
 }

--- a/scripts/get_treasury_collection.cdc
+++ b/scripts/get_treasury_collection.cdc
@@ -1,10 +1,10 @@
-import DAOTreasury from "../contracts/DAOTreasury.cdc"
+import DAOTreasuryV2 from "../contracts/DAOTreasury.cdc"
 import NonFungibleToken from "../contracts/core/NonFungibleToken.cdc"
 
 pub fun main(treasuryAddr: Address, collectionId: String): [&NonFungibleToken.NFT] {
-  let treasury = getAccount(treasuryAddr).getCapability(DAOTreasury.TreasuryPublicPath)
-                    .borrow<&DAOTreasury.Treasury{DAOTreasury.TreasuryPublic}>()
-                    ?? panic("A DAOTreasury doesn't exist here.")
+  let treasury = getAccount(treasuryAddr).getCapability(DAOTreasuryV2.TreasuryPublicPath)
+                    .borrow<&DAOTreasuryV2.Treasury{DAOTreasuryV2.TreasuryPublic}>()
+                    ?? panic("A DAOTreasuryV2 doesn't exist here.")
 
   let collection: &{NonFungibleToken.CollectionPublic} = treasury.borrowCollectionPublic(identifier: collectionId)
   let ids = collection.getIDs()

--- a/scripts/get_treasury_identifiers.cdc
+++ b/scripts/get_treasury_identifiers.cdc
@@ -1,9 +1,9 @@
-import DAOTreasury from "../contracts/DAOTreasury.cdc"
+import DAOTreasuryV2 from "../contracts/DAOTreasury.cdc"
 
 pub fun main(treasuryAddr: Address): [[String]] {
-  let treasury = getAccount(treasuryAddr).getCapability(DAOTreasury.TreasuryPublicPath)
-                    .borrow<&DAOTreasury.Treasury{DAOTreasury.TreasuryPublic}>()
-                    ?? panic("A DAOTreasury doesn't exist here.")
+  let treasury = getAccount(treasuryAddr).getCapability(DAOTreasuryV2.TreasuryPublicPath)
+                    .borrow<&DAOTreasuryV2.Treasury{DAOTreasuryV2.TreasuryPublic}>()
+                    ?? panic("A DAOTreasuryV2 doesn't exist here.")
 
   let answer: [[String]] = []
   answer.append(treasury.getVaultIdentifiers())

--- a/scripts/get_treasury_signers.cdc
+++ b/scripts/get_treasury_signers.cdc
@@ -1,9 +1,9 @@
-import DAOTreasury from "../contracts/DAOTreasury.cdc"
+import DAOTreasuryV2 from "../contracts/DAOTreasury.cdc"
 
 pub fun main(treasuryAddr: Address): {Address: Bool} {
-  let treasury = getAccount(treasuryAddr).getCapability(DAOTreasury.TreasuryPublicPath)
-                    .borrow<&DAOTreasury.Treasury{DAOTreasury.TreasuryPublic}>()
-                    ?? panic("A DAOTreasury doesn't exist here.")
+  let treasury = getAccount(treasuryAddr).getCapability(DAOTreasuryV2.TreasuryPublicPath)
+                    .borrow<&DAOTreasuryV2.Treasury{DAOTreasuryV2.TreasuryPublic}>()
+                    ?? panic("A DAOTreasuryV2 doesn't exist here.")
 
   return treasury.borrowManagerPublic().getSigners()
 }

--- a/scripts/get_treasury_threshold.cdc
+++ b/scripts/get_treasury_threshold.cdc
@@ -1,9 +1,9 @@
-import DAOTreasury from "../contracts/DAOTreasury.cdc"
+import DAOTreasuryV2 from "../contracts/DAOTreasury.cdc"
 
 pub fun main(treasuryAddr: Address): UInt64 {
-  let treasury = getAccount(treasuryAddr).getCapability(DAOTreasury.TreasuryPublicPath)
-                    .borrow<&DAOTreasury.Treasury{DAOTreasury.TreasuryPublic}>()
-                    ?? panic("A DAOTreasury doesn't exist here.")
+  let treasury = getAccount(treasuryAddr).getCapability(DAOTreasuryV2.TreasuryPublicPath)
+                    .borrow<&DAOTreasuryV2.Treasury{DAOTreasuryV2.TreasuryPublic}>()
+                    ?? panic("A DAOTreasuryV2 doesn't exist here.")
 
   return treasury.borrowManagerPublic().getThreshold()
 }

--- a/scripts/get_vault_balance.cdc
+++ b/scripts/get_vault_balance.cdc
@@ -1,10 +1,10 @@
-import DAOTreasury from "../contracts/DAOTreasury.cdc"
+import DAOTreasuryV2 from "../contracts/DAOTreasury.cdc"
 import FungibleToken from "../contracts/core/FungibleToken.cdc"
 
 pub fun main(treasuryAddr: Address, vaultId: String): UFix64 {
-  let treasury = getAccount(treasuryAddr).getCapability(DAOTreasury.TreasuryPublicPath)
-                    .borrow<&DAOTreasury.Treasury{DAOTreasury.TreasuryPublic}>()
-                    ?? panic("A DAOTreasury doesn't exist here.")
+  let treasury = getAccount(treasuryAddr).getCapability(DAOTreasuryV2.TreasuryPublicPath)
+                    .borrow<&DAOTreasuryV2.Treasury{DAOTreasuryV2.TreasuryPublic}>()
+                    ?? panic("A DAOTreasuryV2 doesn't exist here.")
 
   let vault: &{FungibleToken.Balance} = treasury.borrowVaultPublic(identifier: vaultId)
   return vault.balance

--- a/scripts/get_verified_signers_for_action.cdc
+++ b/scripts/get_verified_signers_for_action.cdc
@@ -1,9 +1,9 @@
-import DAOTreasury from "../contracts/DAOTreasury.cdc"
+import DAOTreasuryV2 from "../contracts/DAOTreasury.cdc"
 
 pub fun main(treasuryAddr: Address, actionUUID: UInt64): {Address: Bool} {
-  let treasury = getAccount(treasuryAddr).getCapability(DAOTreasury.TreasuryPublicPath)
-                    .borrow<&DAOTreasury.Treasury{DAOTreasury.TreasuryPublic}>()
-                    ?? panic("A DAOTreasury doesn't exist here.")
+  let treasury = getAccount(treasuryAddr).getCapability(DAOTreasuryV2.TreasuryPublicPath)
+                    .borrow<&DAOTreasuryV2.Treasury{DAOTreasuryV2.TreasuryPublic}>()
+                    ?? panic("A DAOTreasuryV2 doesn't exist here.")
 
   return treasury.borrowManagerPublic().getVerifiedSignersForAction(actionUUID: actionUUID)
 }

--- a/test_utils.go
+++ b/test_utils.go
@@ -64,9 +64,25 @@ func (otu *OverflowTestUtils) SetupTreasuryFail(name string, signers []string, t
 }
 
 func (otu *OverflowTestUtils) ProposeNewThreshold(proposingAcct string, newThreshold uint64) *OverflowTestUtils {
+	src := []byte(fmt.Sprintf("Update the threshold of signers to %d.", newThreshold))
+	hexCollectionID := make([]byte, hex.EncodedLen(len(src)))
+	hex.Encode(hexCollectionID, src)
+
+	// block.ID & block.Height
+	latestBlock, _ := otu.O.GetLatestBlock()
+	// message
+	message := fmt.Sprintf("%s%s", hexCollectionID, latestBlock.ID)
+	// signature
+	signature := otu.SignMessage(proposingAcct, message)
+
 	otu.O.TransactionFromFile("update_threshold").
 		SignProposeAndPayAs(proposingAcct).
-		Args(otu.O.Arguments().UInt64(newThreshold)).
+		Args(otu.O.Arguments().
+			UInt64(newThreshold).
+			String(message).
+			UInt64Array(0).
+			StringArray(signature).
+			UInt64(latestBlock.Height)).
 		Test(otu.T).
 		AssertSuccess()
 
@@ -74,9 +90,25 @@ func (otu *OverflowTestUtils) ProposeNewThreshold(proposingAcct string, newThres
 }
 
 func (otu *OverflowTestUtils) ProposeNewThresholdFail(proposingAcct string, newThreshold uint64, msg string) *OverflowTestUtils {
+	src := []byte("no action id")
+	hexCollectionID := make([]byte, hex.EncodedLen(len(src)))
+	hex.Encode(hexCollectionID, src)
+
+	// block.ID & block.Height
+	latestBlock, _ := otu.O.GetLatestBlock()
+	// message
+	message := fmt.Sprintf("%s%s", hexCollectionID, latestBlock.ID)
+	// signature
+	signature := otu.SignMessage(proposingAcct, message)
+
 	otu.O.TransactionFromFile("update_threshold").
 		SignProposeAndPayAs(proposingAcct).
-		Args(otu.O.Arguments().UInt64(newThreshold)).
+		Args(otu.O.Arguments().
+			UInt64(newThreshold).
+			String(message).
+			UInt64Array(0).
+			StringArray(signature).
+			UInt64(latestBlock.Height)).
 		Test(otu.T).
 		AssertFailure(msg)
 
@@ -140,12 +172,28 @@ func (otu *OverflowTestUtils) SendCollectionToTreasury(from string, to string) *
 }
 
 func (otu *OverflowTestUtils) ProposeFungibleTokenTransferAction(treasuryAcct string, proposingAcct, recipientAcct string, amount float64) *OverflowTestUtils {
+	recipient, _ := otu.O.State.Accounts().ByName(fmt.Sprintf("emulator-%s", recipientAcct))
+	src := []byte(fmt.Sprintf("Transfer %.8f %s tokens from the treasury to 0x%s", amount, "Capability<&AnyResource{A.ee82856bf20e2aa6.FungibleToken.Receiver}>", recipient.Address()))
+	hexCollectionID := make([]byte, hex.EncodedLen(len(src)))
+	hex.Encode(hexCollectionID, src)
+
+	// block.ID & block.Height
+	latestBlock, _ := otu.O.GetLatestBlock()
+	// message
+	message := fmt.Sprintf("%s%s", hexCollectionID, latestBlock.ID)
+	// signature
+	signature := otu.SignMessage(proposingAcct, message)
+
 	otu.O.TransactionFromFile("propose_fungible_token_transfer").
 		SignProposeAndPayAs(proposingAcct).
 		Args(otu.O.Arguments().
 			Account(treasuryAcct).
 			Account(recipientAcct).
-			UFix64(amount)).
+			UFix64(amount).
+			String(message).
+			UInt64Array(0).
+			StringArray(signature).
+			UInt64(latestBlock.Height)).
 		Test(otu.T).
 		AssertSuccess()
 
@@ -154,12 +202,28 @@ func (otu *OverflowTestUtils) ProposeFungibleTokenTransferAction(treasuryAcct st
 
 func (otu *OverflowTestUtils) ProposeFungibleTokenTransferActionFail(treasuryAcct string, proposingAcct, recipientAcct string, amount float64) *OverflowTestUtils {
 	PROPOSE_TOKEN_TRANSFER_ERROR := "Amount should be higher than 0.0"
+
+	src := []byte("no action id")
+	hexCollectionID := make([]byte, hex.EncodedLen(len(src)))
+	hex.Encode(hexCollectionID, src)
+
+	// block.ID & block.Height
+	latestBlock, _ := otu.O.GetLatestBlock()
+	// message
+	message := fmt.Sprintf("%s%s", hexCollectionID, latestBlock.ID)
+	// signature
+	signature := otu.SignMessage(proposingAcct, message)
+
 	otu.O.TransactionFromFile("propose_fungible_token_transfer").
 		SignProposeAndPayAs(proposingAcct).
 		Args(otu.O.Arguments().
 			Account(treasuryAcct).
 			Account(recipientAcct).
-			UFix64(amount)).
+			UFix64(amount).
+			String(message).
+			UInt64Array(0).
+			StringArray(signature).
+			UInt64(latestBlock.Height)).
 		Test(otu.T).
 		AssertFailure(PROPOSE_TOKEN_TRANSFER_ERROR)
 
@@ -167,13 +231,31 @@ func (otu *OverflowTestUtils) ProposeFungibleTokenTransferActionFail(treasuryAcc
 }
 
 func (otu *OverflowTestUtils) ProposeFungibleTokenTransferToTreasuryAction(treasuryAcct string, proposingAcct, recipientAcct string, vaultIdentifier string, amount float64) *OverflowTestUtils {
+
+	recipient, _ := otu.O.State.Accounts().ByName(fmt.Sprintf("emulator-%s", recipientAcct))
+	src := []byte(fmt.Sprintf("Transfer %.8f %s tokens from the treasury to 0x%s", amount, vaultIdentifier, recipient.Address()))
+
+	hexCollectionID := make([]byte, hex.EncodedLen(len(src)))
+	hex.Encode(hexCollectionID, src)
+
+	// block.ID & block.Height
+	latestBlock, _ := otu.O.GetLatestBlock()
+	// message
+	message := fmt.Sprintf("%s%s", hexCollectionID, latestBlock.ID)
+	// signature
+	signature := otu.SignMessage(proposingAcct, message)
+
 	otu.O.TransactionFromFile("propose_fungible_token_transfer_to_treasury").
 		SignProposeAndPayAs(proposingAcct).
 		Args(otu.O.Arguments().
 			Account(treasuryAcct).
 			Account(recipientAcct).
 			String(vaultIdentifier).
-			UFix64(amount)).
+			UFix64(amount).
+			String(message).
+			UInt64Array(0).
+			StringArray(signature).
+			UInt64(latestBlock.Height)).
 		Test(otu.T).
 		AssertSuccess()
 
@@ -183,13 +265,28 @@ func (otu *OverflowTestUtils) ProposeFungibleTokenTransferToTreasuryAction(treas
 func (otu *OverflowTestUtils) ProposeFungibleTokenTransferToTreasuryActionFail(treasuryAcct string, proposingAcct, recipientAcct string, vaultIdentifier string, amount float64) *OverflowTestUtils {
 	PROPOSE_TOKEN_TRANSFER_ERROR := "Amount should be higher than 0.0"
 
+	src := []byte("no action id")
+	hexCollectionID := make([]byte, hex.EncodedLen(len(src)))
+	hex.Encode(hexCollectionID, src)
+
+	// block.ID & block.Height
+	latestBlock, _ := otu.O.GetLatestBlock()
+	// message
+	message := fmt.Sprintf("%s%s", hexCollectionID, latestBlock.ID)
+	// signature
+	signature := otu.SignMessage(proposingAcct, message)
+
 	otu.O.TransactionFromFile("propose_fungible_token_transfer_to_treasury").
 		SignProposeAndPayAs(proposingAcct).
 		Args(otu.O.Arguments().
 			Account(treasuryAcct).
 			Account(recipientAcct).
 			String(vaultIdentifier).
-			UFix64(amount)).
+			UFix64(amount).
+			String(message).
+			UInt64Array(0).
+			StringArray(signature).
+			UInt64(latestBlock.Height)).
 		Test(otu.T).
 		AssertFailure(PROPOSE_TOKEN_TRANSFER_ERROR)
 
@@ -197,12 +294,30 @@ func (otu *OverflowTestUtils) ProposeFungibleTokenTransferToTreasuryActionFail(t
 }
 
 func (otu *OverflowTestUtils) ProposeNonFungibleTokenTransferAction(treasuryAcct string, proposingAcct, recipientAcct string, id uint64) *OverflowTestUtils {
+
+	recipient, _ := otu.O.State.Accounts().ByName(fmt.Sprintf("emulator-%s", recipientAcct))
+	src := []byte(fmt.Sprintf("Transfer a %s NFT from the treasury to 0x%s", "Capability<&AnyResource{A.f8d6e0586b0a20c7.NonFungibleToken.CollectionPublic}>", recipient.Address()))
+
+	hexCollectionID := make([]byte, hex.EncodedLen(len(src)))
+	hex.Encode(hexCollectionID, src)
+
+	// block.ID & block.Height
+	latestBlock, _ := otu.O.GetLatestBlock()
+	// message
+	message := fmt.Sprintf("%s%s", hexCollectionID, latestBlock.ID)
+	// signature
+	signature := otu.SignMessage(proposingAcct, message)
+
 	otu.O.TransactionFromFile("propose_non_fungible_token_transfer").
 		SignProposeAndPayAs(proposingAcct).
 		Args(otu.O.Arguments().
 			Account(treasuryAcct).
 			Account(recipientAcct).
-			UInt64(id)).
+			UInt64(id).
+			String(message).
+			UInt64Array(0).
+			StringArray(signature).
+			UInt64(latestBlock.Height)).
 		Test(otu.T).
 		AssertSuccess()
 
@@ -210,13 +325,31 @@ func (otu *OverflowTestUtils) ProposeNonFungibleTokenTransferAction(treasuryAcct
 }
 
 func (otu *OverflowTestUtils) ProposeNonFungibleTokenTransferToTreasuryAction(treasuryAcct string, proposingAcct, recipientAcct string, collectionIdentifier string, id uint64) *OverflowTestUtils {
+
+	recipient, _ := otu.O.State.Accounts().ByName(fmt.Sprintf("emulator-%s", recipientAcct))
+	src := []byte(fmt.Sprintf("Transfer an NFT from collection %s with ID %s from this Treasury to Treasury at address 0x%s", collectionIdentifier, fmt.Sprint(id), recipient.Address()))
+
+	hexCollectionID := make([]byte, hex.EncodedLen(len(src)))
+	hex.Encode(hexCollectionID, src)
+
+	// block.ID & block.Height
+	latestBlock, _ := otu.O.GetLatestBlock()
+	// message
+	message := fmt.Sprintf("%s%s", hexCollectionID, latestBlock.ID)
+	// signature
+	signature := otu.SignMessage(proposingAcct, message)
+
 	otu.O.TransactionFromFile("propose_non_fungible_token_transfer_to_treasury").
 		SignProposeAndPayAs(proposingAcct).
 		Args(otu.O.Arguments().
 			Account(treasuryAcct).
 			Account(recipientAcct).
 			String(collectionIdentifier).
-			UInt64(id)).
+			UInt64(id).
+			String(message).
+			UInt64Array(0).
+			StringArray(signature).
+			UInt64(latestBlock.Height)).
 		Test(otu.T).
 		AssertSuccess()
 
@@ -263,9 +396,26 @@ func (otu *OverflowTestUtils) GetTreasuryThreshold(account string) uint64 {
 }
 
 func (otu *OverflowTestUtils) ProposeAddSignerAction(proposingAcct, address string) *OverflowTestUtils {
+	signerAccount, _ := otu.O.State.Accounts().ByName(fmt.Sprintf("emulator-%s", address))
+	src := []byte(fmt.Sprintf("Add account 0x%s as a signer.", signerAccount.Address()))
+	signerHex := make([]byte, hex.EncodedLen(len(src)))
+	hex.Encode(signerHex, src)
+
+	// block.ID & block.Height
+	latestBlock, _ := otu.O.GetLatestBlock()
+	// message
+	message := fmt.Sprintf("%s%s", signerHex, latestBlock.ID)
+	// signature
+	signature := otu.SignMessage(proposingAcct, message)
+
 	otu.O.TransactionFromFile("add_signer").
 		SignProposeAndPayAs(proposingAcct).
-		Args(otu.O.Arguments().Address(address)).
+		Args(otu.O.Arguments().
+			Address(address).
+			String(message).
+			UInt64Array(0).
+			StringArray(signature).
+			UInt64(latestBlock.Height)).
 		Test(otu.T).
 		AssertSuccess()
 
@@ -273,9 +423,26 @@ func (otu *OverflowTestUtils) ProposeAddSignerAction(proposingAcct, address stri
 }
 
 func (otu *OverflowTestUtils) ProposeRemoveSignerAction(proposingAcct, address string) *OverflowTestUtils {
+	signerAccount, _ := otu.O.State.Accounts().ByName(fmt.Sprintf("emulator-%s", address))
+	src := []byte(fmt.Sprintf("Remove 0x%s as a signer.", signerAccount.Address()))
+	hexCollectionID := make([]byte, hex.EncodedLen(len(src)))
+	hex.Encode(hexCollectionID, src)
+
+	// block.ID & block.Height
+	latestBlock, _ := otu.O.GetLatestBlock()
+	// message
+	message := fmt.Sprintf("%s%s", hexCollectionID, latestBlock.ID)
+	// signature
+	signature := otu.SignMessage(proposingAcct, message)
+
 	otu.O.TransactionFromFile("remove_signer").
 		SignProposeAndPayAs(proposingAcct).
-		Args(otu.O.Arguments().Address(address)).
+		Args(otu.O.Arguments().
+			Address(address).
+			String(message).
+			UInt64Array(0).
+			StringArray(signature).
+			UInt64(latestBlock.Height)).
 		Test(otu.T).
 		AssertSuccess()
 
@@ -446,11 +613,26 @@ func (otu *OverflowTestUtils) GetTotalVerifiedForAction(treasuryAcct string, act
 }
 
 func (otu *OverflowTestUtils) ExecuteAction(treasuryAcct string, actionUUID uint64) *OverflowTestUtils {
+	src := []byte(fmt.Sprint(actionUUID))
+	hexID := make([]byte, hex.EncodedLen(len(src)))
+	hex.Encode(hexID, src)
+
+	// block.ID & block.Height
+	latestBlock, _ := otu.O.GetLatestBlock()
+	// message
+	message := fmt.Sprintf("%s%s", hexID, latestBlock.ID)
+	// signature
+	signature := otu.SignMessage(treasuryAcct, message)
+
 	otu.O.TransactionFromFile("execute_action").
-		SignProposeAndPayAs("signer1").
+		SignProposeAndPayAs(treasuryAcct).
 		Args(otu.O.Arguments().
 			Account(treasuryAcct).
-			UInt64(actionUUID)).
+			UInt64(actionUUID).
+			String(message).
+			UInt64Array(0).
+			StringArray(signature).
+			UInt64(latestBlock.Height)).
 		Test(otu.T).
 		AssertSuccess()
 
@@ -458,11 +640,26 @@ func (otu *OverflowTestUtils) ExecuteAction(treasuryAcct string, actionUUID uint
 }
 
 func (otu *OverflowTestUtils) ExecuteActionFailed(treasuryAcct string, actionUUID uint64, msg string) *OverflowTestUtils {
+	src := []byte(fmt.Sprint(actionUUID))
+	hexID := make([]byte, hex.EncodedLen(len(src)))
+	hex.Encode(hexID, src)
+
+	// block.ID & block.Height
+	latestBlock, _ := otu.O.GetLatestBlock()
+	// message
+	message := fmt.Sprintf("%s%s", hexID, latestBlock.ID)
+	// signature
+	signature := otu.SignMessage(treasuryAcct, message)
+
 	otu.O.TransactionFromFile("execute_action").
-		SignProposeAndPayAs("signer1").
+		SignProposeAndPayAs(treasuryAcct).
 		Args(otu.O.Arguments().
 			Account(treasuryAcct).
-			UInt64(actionUUID)).
+			UInt64(actionUUID).
+			String(message).
+			UInt64Array(0).
+			StringArray(signature).
+			UInt64(latestBlock.Height)).
 		Test(otu.T).
 		AssertFailure(msg)
 
@@ -470,11 +667,26 @@ func (otu *OverflowTestUtils) ExecuteActionFailed(treasuryAcct string, actionUUI
 }
 
 func (otu *OverflowTestUtils) ProposeDestroyAction(treasuryAcct string, actionUUID uint64) *OverflowTestUtils {
+	src := []byte(fmt.Sprintf("Remove the action %d from the Treasury.", actionUUID))
+	hexCollectionID := make([]byte, hex.EncodedLen(len(src)))
+	hex.Encode(hexCollectionID, src)
+
+	// block.ID & block.Height
+	latestBlock, _ := otu.O.GetLatestBlock()
+	// message
+	message := fmt.Sprintf("%s%s", hexCollectionID, latestBlock.ID)
+	// signature
+	signature := otu.SignMessage(treasuryAcct, message)
+
 	otu.O.TransactionFromFile("destroy_action").
-		SignProposeAndPayAs("signer1").
+		SignProposeAndPayAs(treasuryAcct).
 		Args(otu.O.Arguments().
 			Account(treasuryAcct).
-			UInt64(actionUUID)).
+			UInt64(actionUUID).
+			String(message).
+			UInt64Array(0).
+			StringArray(signature).
+			UInt64(latestBlock.Height)).
 		Test(otu.T).
 		AssertSuccess()
 

--- a/test_utils.go
+++ b/test_utils.go
@@ -63,7 +63,7 @@ func (otu *OverflowTestUtils) SetupTreasuryFail(name string, signers []string, t
 	return otu
 }
 
-func (otu *OverflowTestUtils) ProposeNewThreshold(proposingAcct string, newThreshold uint64) *OverflowTestUtils {
+func (otu *OverflowTestUtils) ProposeNewThreshold(treasuryAddr, proposingAcct string, newThreshold uint64) *OverflowTestUtils {
 	src := []byte(fmt.Sprintf("Update the threshold of signers to %d.", newThreshold))
 	hexCollectionID := make([]byte, hex.EncodedLen(len(src)))
 	hex.Encode(hexCollectionID, src)
@@ -78,6 +78,7 @@ func (otu *OverflowTestUtils) ProposeNewThreshold(proposingAcct string, newThres
 	otu.O.TransactionFromFile("update_threshold").
 		SignProposeAndPayAs(proposingAcct).
 		Args(otu.O.Arguments().
+			Address(treasuryAddr).
 			UInt64(newThreshold).
 			String(message).
 			UInt64Array(0).
@@ -395,7 +396,7 @@ func (otu *OverflowTestUtils) GetTreasuryThreshold(account string) uint64 {
 	return threshold.ToGoValue().(uint64)
 }
 
-func (otu *OverflowTestUtils) ProposeAddSignerAction(proposingAcct, address string) *OverflowTestUtils {
+func (otu *OverflowTestUtils) ProposeAddSignerAction(treasuryAddr, proposingAcct, address string) *OverflowTestUtils {
 	signerAccount, _ := otu.O.State.Accounts().ByName(fmt.Sprintf("emulator-%s", address))
 	src := []byte(fmt.Sprintf("Add account 0x%s as a signer.", signerAccount.Address()))
 	signerHex := make([]byte, hex.EncodedLen(len(src)))
@@ -411,6 +412,7 @@ func (otu *OverflowTestUtils) ProposeAddSignerAction(proposingAcct, address stri
 	otu.O.TransactionFromFile("add_signer").
 		SignProposeAndPayAs(proposingAcct).
 		Args(otu.O.Arguments().
+			Address(treasuryAddr).
 			Address(address).
 			String(message).
 			UInt64Array(0).
@@ -422,7 +424,7 @@ func (otu *OverflowTestUtils) ProposeAddSignerAction(proposingAcct, address stri
 	return otu
 }
 
-func (otu *OverflowTestUtils) ProposeRemoveSignerAction(proposingAcct, address string) *OverflowTestUtils {
+func (otu *OverflowTestUtils) ProposeRemoveSignerAction(treasuryAddr, proposingAcct, address string) *OverflowTestUtils {
 	signerAccount, _ := otu.O.State.Accounts().ByName(fmt.Sprintf("emulator-%s", address))
 	src := []byte(fmt.Sprintf("Remove 0x%s as a signer.", signerAccount.Address()))
 	hexCollectionID := make([]byte, hex.EncodedLen(len(src)))
@@ -438,6 +440,7 @@ func (otu *OverflowTestUtils) ProposeRemoveSignerAction(proposingAcct, address s
 	otu.O.TransactionFromFile("remove_signer").
 		SignProposeAndPayAs(proposingAcct).
 		Args(otu.O.Arguments().
+			Address(treasuryAddr).
 			Address(address).
 			String(message).
 			UInt64Array(0).

--- a/transactions/add_signer.cdc
+++ b/transactions/add_signer.cdc
@@ -1,16 +1,29 @@
 import DAOTreasury from "../contracts/DAOTreasury.cdc"
 import TreasuryActions from "../contracts/TreasuryActions.cdc"
+import MyMultiSig from "../contracts/MyMultiSig.cdc"
 
-transaction(additionalSigner: Address) {
+transaction(additionalSigner: Address, message: String, keyIds: [UInt64], signatures: [String], signatureBlock: UInt64) {
   
-  let Treasury: &DAOTreasury.Treasury{DAOTreasury.TreasuryPublic}
+  let treasury: &DAOTreasury.Treasury{DAOTreasury.TreasuryPublic}
+  let action: AnyStruct{MyMultiSig.Action}
+  let messageSignaturePayload: MyMultiSig.MessageSignaturePayload
 
   prepare(signer: AuthAccount) {
-    self.Treasury = signer.borrow<&DAOTreasury.Treasury>(from: DAOTreasury.TreasuryStoragePath)
+    self.treasury = signer.borrow<&DAOTreasury.Treasury>(from: DAOTreasury.TreasuryStoragePath)
                     ?? panic("Could not borrow the DAOTreasury")
+    self.action = TreasuryActions.AddSigner(additionalSigner, signer.address)
+    
+    var _keyIds: [Int] = []
+
+    for keyId in keyIds {
+        _keyIds.append(Int(keyId))
+    }
+
+    self.messageSignaturePayload = MyMultiSig.MessageSignaturePayload(
+        _signingAddr: signer.address, _message: message, _keyIds: _keyIds, _signatures: signatures, _signatureBlock: signatureBlock
+    )
   }
   execute {
-    let action = TreasuryActions.AddSigner(_signer: additionalSigner)
-    self.Treasury.proposeAction(action: action)
+    self.treasury.proposeAction(action: self.action, signaturePayload: self.messageSignaturePayload)
   }
 }

--- a/transactions/add_signer.cdc
+++ b/transactions/add_signer.cdc
@@ -2,15 +2,16 @@ import DAOTreasury from "../contracts/DAOTreasury.cdc"
 import TreasuryActions from "../contracts/TreasuryActions.cdc"
 import MyMultiSig from "../contracts/MyMultiSig.cdc"
 
-transaction(additionalSigner: Address, message: String, keyIds: [UInt64], signatures: [String], signatureBlock: UInt64) {
+transaction(treasuryAddr: Address, additionalSigner: Address, message: String, keyIds: [UInt64], signatures: [String], signatureBlock: UInt64) {
   
   let treasury: &DAOTreasury.Treasury{DAOTreasury.TreasuryPublic}
   let action: AnyStruct{MyMultiSig.Action}
   let messageSignaturePayload: MyMultiSig.MessageSignaturePayload
 
   prepare(signer: AuthAccount) {
-    self.treasury = signer.borrow<&DAOTreasury.Treasury>(from: DAOTreasury.TreasuryStoragePath)
-                    ?? panic("Could not borrow the DAOTreasury")
+    self.treasury = getAccount(treasuryAddr).getCapability(DAOTreasury.TreasuryPublicPath)
+                    .borrow<&DAOTreasury.Treasury{DAOTreasury.TreasuryPublic}>()
+                    ?? panic("A DAOTreasury doesn't exist here.")
     self.action = TreasuryActions.AddSigner(additionalSigner, signer.address)
     
     var _keyIds: [Int] = []

--- a/transactions/add_signer.cdc
+++ b/transactions/add_signer.cdc
@@ -1,18 +1,18 @@
-import DAOTreasury from "../contracts/DAOTreasury.cdc"
-import TreasuryActions from "../contracts/TreasuryActions.cdc"
-import MyMultiSig from "../contracts/MyMultiSig.cdc"
+import DAOTreasuryV2 from "../contracts/DAOTreasury.cdc"
+import TreasuryActionsV2 from "../contracts/TreasuryActions.cdc"
+import MyMultiSigV2 from "../contracts/MyMultiSig.cdc"
 
 transaction(treasuryAddr: Address, additionalSigner: Address, message: String, keyIds: [UInt64], signatures: [String], signatureBlock: UInt64) {
   
-  let treasury: &DAOTreasury.Treasury{DAOTreasury.TreasuryPublic}
-  let action: AnyStruct{MyMultiSig.Action}
-  let messageSignaturePayload: MyMultiSig.MessageSignaturePayload
+  let treasury: &DAOTreasuryV2.Treasury{DAOTreasuryV2.TreasuryPublic}
+  let action: AnyStruct{MyMultiSigV2.Action}
+  let messageSignaturePayload: MyMultiSigV2.MessageSignaturePayload
 
   prepare(signer: AuthAccount) {
-    self.treasury = getAccount(treasuryAddr).getCapability(DAOTreasury.TreasuryPublicPath)
-                    .borrow<&DAOTreasury.Treasury{DAOTreasury.TreasuryPublic}>()
-                    ?? panic("A DAOTreasury doesn't exist here.")
-    self.action = TreasuryActions.AddSigner(_signer: additionalSigner, _proposer: signer.address)
+    self.treasury = getAccount(treasuryAddr).getCapability(DAOTreasuryV2.TreasuryPublicPath)
+                    .borrow<&DAOTreasuryV2.Treasury{DAOTreasuryV2.TreasuryPublic}>()
+                    ?? panic("A DAOTreasuryV2 doesn't exist here.")
+    self.action = TreasuryActionsV2.AddSigner(_signer: additionalSigner, _proposer: signer.address)
     
     var _keyIds: [Int] = []
 
@@ -20,7 +20,7 @@ transaction(treasuryAddr: Address, additionalSigner: Address, message: String, k
         _keyIds.append(Int(keyId))
     }
 
-    self.messageSignaturePayload = MyMultiSig.MessageSignaturePayload(
+    self.messageSignaturePayload = MyMultiSigV2.MessageSignaturePayload(
         _signingAddr: signer.address, _message: message, _keyIds: _keyIds, _signatures: signatures, _signatureBlock: signatureBlock
     )
   }

--- a/transactions/attempt_borrow_action_execute_exploit.cdc
+++ b/transactions/attempt_borrow_action_execute_exploit.cdc
@@ -1,17 +1,17 @@
-import DAOTreasury from "../contracts/DAOTreasury.cdc"
+import DAOTreasuryV2 from "../contracts/DAOTreasury.cdc"
 
 transaction(uuid: UInt64) {
   
   prepare(signer: AuthAccount) {
-    let treasury <- signer.load<@DAOTreasury.Treasury>(from: DAOTreasury.TreasuryStoragePath)
+    let treasury <- signer.load<@DAOTreasuryV2.Treasury>(from: DAOTreasuryV2.TreasuryStoragePath)
     let manager = treasury?.borrowManagerPublic()
 
     let action = manager?.borrowAction(actionUUID: uuid)
 
-    let treasuryRef: &DAOTreasury.Treasury = (&treasury as &DAOTreasury.Treasury?)!
+    let treasuryRef: &DAOTreasuryV2.Treasury = (&treasury as &DAOTreasuryV2.Treasury?)!
     action?.action?.execute({"treasury": treasuryRef})
 
-    signer.save(<-treasury, to: DAOTreasury.TreasuryStoragePath)
+    signer.save(<-treasury, to: DAOTreasuryV2.TreasuryStoragePath)
   }
   execute {
     

--- a/transactions/attempt_borrow_action_total_verified_exploit.cdc
+++ b/transactions/attempt_borrow_action_total_verified_exploit.cdc
@@ -1,17 +1,17 @@
-import DAOTreasury from "../contracts/DAOTreasury.cdc"
-import MyMultiSig from "../contracts/MyMultiSig.cdc"
+import DAOTreasuryV2 from "../contracts/DAOTreasury.cdc"
+import MyMultiSigV2 from "../contracts/MyMultiSig.cdc"
 
 transaction(uuid: UInt64) {
   
   prepare(signer: AuthAccount) {
-    let treasury <- signer.load<@DAOTreasury.Treasury>(from: DAOTreasury.TreasuryStoragePath)
+    let treasury <- signer.load<@DAOTreasuryV2.Treasury>(from: DAOTreasuryV2.TreasuryStoragePath)
     let manager = treasury?.borrowManagerPublic()
 
-    let action = (manager?.borrowAction(actionUUID: uuid) as &MyMultiSig.MultiSignAction?)!
+    let action = (manager?.borrowAction(actionUUID: uuid) as &MyMultiSigV2.MultiSignAction?)!
 
     action.totalVerified = 100
 
-    signer.save(<-treasury, to: DAOTreasury.TreasuryStoragePath)
+    signer.save(<-treasury, to: DAOTreasuryV2.TreasuryStoragePath)
   }
   execute {
     

--- a/transactions/attempt_borrow_manager_exploit.cdc
+++ b/transactions/attempt_borrow_manager_exploit.cdc
@@ -1,15 +1,15 @@
-import DAOTreasury from "../contracts/DAOTreasury.cdc"
+import DAOTreasuryV2 from "../contracts/DAOTreasury.cdc"
 
 transaction() {
   
   prepare(signer: AuthAccount) {
-    let treasury <- signer.load<@DAOTreasury.Treasury>(from: DAOTreasury.TreasuryStoragePath)
+    let treasury <- signer.load<@DAOTreasuryV2.Treasury>(from: DAOTreasuryV2.TreasuryStoragePath)
     let manager = treasury?.borrowManager()
 
     // Attempt to bypass multi-sign and unilaterally update the signature threshold
     manager?.updateThreshold(newThreshold: 100)
 
-    signer.save(<-treasury, to: DAOTreasury.TreasuryStoragePath)
+    signer.save(<-treasury, to: DAOTreasuryV2.TreasuryStoragePath)
   }
   execute {
     

--- a/transactions/attempt_direct_manager_access.cdc
+++ b/transactions/attempt_direct_manager_access.cdc
@@ -1,14 +1,14 @@
-import DAOTreasury from "../contracts/DAOTreasury.cdc"
+import DAOTreasuryV2 from "../contracts/DAOTreasury.cdc"
 
 transaction() {
   
   prepare(signer: AuthAccount) {
-    let treasury <- signer.load<@DAOTreasury.Treasury>(from: DAOTreasury.TreasuryStoragePath)
+    let treasury <- signer.load<@DAOTreasuryV2.Treasury>(from: DAOTreasuryV2.TreasuryStoragePath)
 
     // Attempt to bypass multi-sign and unilaterally update the signature threshold
     treasury?.multiSignManager?.updateThreshold(newThreshold: 100)
 
-    signer.save(<-treasury, to: DAOTreasury.TreasuryStoragePath)
+    signer.save(<-treasury, to: DAOTreasuryV2.TreasuryStoragePath)
   }
   execute {
     

--- a/transactions/attempt_withdraw_NFT_exploit.cdc
+++ b/transactions/attempt_withdraw_NFT_exploit.cdc
@@ -1,17 +1,17 @@
-import DAOTreasury from "../contracts/DAOTreasury.cdc"
+import DAOTreasuryV2 from "../contracts/DAOTreasury.cdc"
 transaction() {
   
   prepare(signer: AuthAccount) {
     let COLLECTION_ID =  "A.f8d6e0586b0a20c7.ExampleNFT.Collection"
     
-    let treasury <- signer.load<@DAOTreasury.Treasury>(from: DAOTreasury.TreasuryStoragePath)
-        ?? panic("A DAOTreasury doesn't exist here.")
+    let treasury <- signer.load<@DAOTreasuryV2.Treasury>(from: DAOTreasuryV2.TreasuryStoragePath)
+        ?? panic("A DAOTreasuryV2 doesn't exist here.")
 
     let nft <- treasury.withdrawNFT(identifier: COLLECTION_ID, id:0)
 
     // Do malicious stuff with unrestricted nft reference
     destroy nft
-    signer.save(<-treasury, to: DAOTreasury.TreasuryStoragePath)
+    signer.save(<-treasury, to: DAOTreasuryV2.TreasuryStoragePath)
 
   }
   execute {

--- a/transactions/attempt_withdraw_tokens_exploit.cdc
+++ b/transactions/attempt_withdraw_tokens_exploit.cdc
@@ -1,18 +1,18 @@
-import DAOTreasury from "../contracts/DAOTreasury.cdc"
+import DAOTreasuryV2 from "../contracts/DAOTreasury.cdc"
 
 transaction() {
   
   prepare(signer: AuthAccount) {
     let VAULT_ID = "A.0ae53cb6e3f42a79.FlowToken.Vault"
 
-    let treasury <- signer.load<@DAOTreasury.Treasury>(from: DAOTreasury.TreasuryStoragePath)
-        ?? panic("A DAOTreasury doesn't exist here.")
+    let treasury <- signer.load<@DAOTreasuryV2.Treasury>(from: DAOTreasuryV2.TreasuryStoragePath)
+        ?? panic("A DAOTreasuryV2 doesn't exist here.")
     let tokens <- treasury.withdrawTokens(identifier:VAULT_ID, amount:UFix64(1))
 
     // Do malicious stuff with unrestricted token reference
     
     destroy tokens
-    signer.save(<-treasury, to: DAOTreasury.TreasuryStoragePath)
+    signer.save(<-treasury, to: DAOTreasuryV2.TreasuryStoragePath)
   }
   execute {
     

--- a/transactions/create_treasury.cdc
+++ b/transactions/create_treasury.cdc
@@ -1,11 +1,11 @@
-import DAOTreasury from "../contracts/DAOTreasury.cdc"
+import DAOTreasuryV2 from "../contracts/DAOTreasury.cdc"
 import FlowToken from "../contracts/core/FlowToken.cdc"
 import FUSD from "../contracts/core/FUSD.cdc"
 
 transaction(initialSigners: [Address], initialThreshold: UInt64) {
   
   prepare(signer: AuthAccount) {
-    let treasury <- DAOTreasury.createTreasury(initialSigners: initialSigners, initialThreshold: initialThreshold)
+    let treasury <- DAOTreasuryV2.createTreasury(initialSigners: initialSigners, initialThreshold: initialThreshold)
 
     // Seed Treasury with commonly used vaults
     let flowVault <- FlowToken.createEmptyVault()
@@ -15,7 +15,7 @@ transaction(initialSigners: [Address], initialThreshold: UInt64) {
     treasury.depositVault(vault: <- fusdVault)
 
     // Save Treasury to the account
-    signer.save(<- treasury, to: DAOTreasury.TreasuryStoragePath)
-    signer.link<&DAOTreasury.Treasury{DAOTreasury.TreasuryPublic}>(DAOTreasury.TreasuryPublicPath, target: DAOTreasury.TreasuryStoragePath)
+    signer.save(<- treasury, to: DAOTreasuryV2.TreasuryStoragePath)
+    signer.link<&DAOTreasuryV2.Treasury{DAOTreasuryV2.TreasuryPublic}>(DAOTreasuryV2.TreasuryPublicPath, target: DAOTreasuryV2.TreasuryStoragePath)
   }
 }

--- a/transactions/destroy_action.cdc
+++ b/transactions/destroy_action.cdc
@@ -1,17 +1,30 @@
 import DAOTreasury from "../contracts/DAOTreasury.cdc"
 import TreasuryActions from "../contracts/TreasuryActions.cdc"
+import MyMultiSig from "../contracts/MyMultiSig.cdc"
 
-transaction(treasuryAddr: Address, actionUUID: UInt64) {
+transaction(treasuryAddr: Address, actionUUID: UInt64, message: String, keyIds: [UInt64], signatures: [String], signatureBlock: UInt64) {
 
-  let Treasury: &DAOTreasury.Treasury{DAOTreasury.TreasuryPublic}
+  let treasury: &DAOTreasury.Treasury{DAOTreasury.TreasuryPublic}
+  let action: AnyStruct{MyMultiSig.Action}
+  let messageSignaturePayload: MyMultiSig.MessageSignaturePayload
   
   prepare(signer: AuthAccount) {
-    self.Treasury = getAccount(treasuryAddr).getCapability(DAOTreasury.TreasuryPublicPath)
+    self.treasury = getAccount(treasuryAddr).getCapability(DAOTreasury.TreasuryPublicPath)
                     .borrow<&DAOTreasury.Treasury{DAOTreasury.TreasuryPublic}>()
                     ?? panic("A DAOTreasury doesn't exist here.")        
+    self.action = TreasuryActions.DestroyAction(actionUUID, signer.address)
+        
+    var _keyIds: [Int] = []
+
+    for keyId in keyIds {
+        _keyIds.append(Int(keyId))
+    }
+
+    self.messageSignaturePayload = MyMultiSig.MessageSignaturePayload(
+        _signingAddr: signer.address, _message: message, _keyIds: _keyIds, _signatures: signatures, _signatureBlock: signatureBlock
+    )
   }
   execute {
-    let action = TreasuryActions.DestroyAction(_actionUUID: actionUUID)
-    self.Treasury.proposeAction(action: action)
+    self.treasury.proposeAction(action: self.action, signaturePayload: self.messageSignaturePayload)
   }
 }

--- a/transactions/destroy_action.cdc
+++ b/transactions/destroy_action.cdc
@@ -1,18 +1,18 @@
-import DAOTreasury from "../contracts/DAOTreasury.cdc"
-import TreasuryActions from "../contracts/TreasuryActions.cdc"
-import MyMultiSig from "../contracts/MyMultiSig.cdc"
+import DAOTreasuryV2 from "../contracts/DAOTreasury.cdc"
+import TreasuryActionsV2 from "../contracts/TreasuryActions.cdc"
+import MyMultiSigV2 from "../contracts/MyMultiSig.cdc"
 
 transaction(treasuryAddr: Address, actionUUID: UInt64, message: String, keyIds: [UInt64], signatures: [String], signatureBlock: UInt64) {
 
-  let treasury: &DAOTreasury.Treasury{DAOTreasury.TreasuryPublic}
-  let action: AnyStruct{MyMultiSig.Action}
-  let messageSignaturePayload: MyMultiSig.MessageSignaturePayload
+  let treasury: &DAOTreasuryV2.Treasury{DAOTreasuryV2.TreasuryPublic}
+  let action: AnyStruct{MyMultiSigV2.Action}
+  let messageSignaturePayload: MyMultiSigV2.MessageSignaturePayload
   
   prepare(signer: AuthAccount) {
-    self.treasury = getAccount(treasuryAddr).getCapability(DAOTreasury.TreasuryPublicPath)
-                    .borrow<&DAOTreasury.Treasury{DAOTreasury.TreasuryPublic}>()
-                    ?? panic("A DAOTreasury doesn't exist here.")        
-    self.action = TreasuryActions.DestroyAction(_actionUUID: actionUUID, _proposer: signer.address)
+    self.treasury = getAccount(treasuryAddr).getCapability(DAOTreasuryV2.TreasuryPublicPath)
+                    .borrow<&DAOTreasuryV2.Treasury{DAOTreasuryV2.TreasuryPublic}>()
+                    ?? panic("A DAOTreasuryV2 doesn't exist here.")        
+    self.action = TreasuryActionsV2.DestroyAction(_actionUUID: actionUUID, _proposer: signer.address)
         
     var _keyIds: [Int] = []
 
@@ -20,7 +20,7 @@ transaction(treasuryAddr: Address, actionUUID: UInt64, message: String, keyIds: 
         _keyIds.append(Int(keyId))
     }
 
-    self.messageSignaturePayload = MyMultiSig.MessageSignaturePayload(
+    self.messageSignaturePayload = MyMultiSigV2.MessageSignaturePayload(
         _signingAddr: signer.address, _message: message, _keyIds: _keyIds, _signatures: signatures, _signatureBlock: signatureBlock
     )
   }

--- a/transactions/destroy_treasury.cdc
+++ b/transactions/destroy_treasury.cdc
@@ -1,10 +1,10 @@
-import DAOTreasury from "../contracts/DAOTreasury.cdc"
+import DAOTreasuryV2 from "../contracts/DAOTreasury.cdc"
 
 transaction() {
-  var treasury: @DAOTreasury.Treasury
+  var treasury: @DAOTreasuryV2.Treasury
 
   prepare(signer: AuthAccount) {
-    self.treasury <- signer.load<@DAOTreasury.Treasury>(from: DAOTreasury.TreasuryStoragePath)!
+    self.treasury <- signer.load<@DAOTreasuryV2.Treasury>(from: DAOTreasuryV2.TreasuryStoragePath)!
   }
   
   execute {

--- a/transactions/execute_action.cdc
+++ b/transactions/execute_action.cdc
@@ -1,22 +1,22 @@
-import DAOTreasury from "../contracts/DAOTreasury.cdc"
-import MyMultiSig from "../contracts/MyMultiSig.cdc"
+import DAOTreasuryV2 from "../contracts/DAOTreasury.cdc"
+import MyMultiSigV2 from "../contracts/MyMultiSig.cdc"
 
 transaction(treasuryAddr: Address, actionUUID: UInt64, message: String, keyIds: [UInt64], signatures: [String], signatureBlock: UInt64) {
 
-  let treasury: &DAOTreasury.Treasury{DAOTreasury.TreasuryPublic}
-  let messageSignaturePayload: MyMultiSig.MessageSignaturePayload
+  let treasury: &DAOTreasuryV2.Treasury{DAOTreasuryV2.TreasuryPublic}
+  let messageSignaturePayload: MyMultiSigV2.MessageSignaturePayload
   
   prepare(signer: AuthAccount) {
-    self.treasury = getAccount(treasuryAddr).getCapability(DAOTreasury.TreasuryPublicPath)
-                    .borrow<&DAOTreasury.Treasury{DAOTreasury.TreasuryPublic}>()
-                    ?? panic("A DAOTreasury doesn't exist here.")
+    self.treasury = getAccount(treasuryAddr).getCapability(DAOTreasuryV2.TreasuryPublicPath)
+                    .borrow<&DAOTreasuryV2.Treasury{DAOTreasuryV2.TreasuryPublic}>()
+                    ?? panic("A DAOTreasuryV2 doesn't exist here.")
     var _keyIds: [Int] = []
 
     for keyId in keyIds {
         _keyIds.append(Int(keyId))
     }
 
-    self.messageSignaturePayload = MyMultiSig.MessageSignaturePayload(
+    self.messageSignaturePayload = MyMultiSigV2.MessageSignaturePayload(
         _signingAddr: signer.address, _message: message, _keyIds: _keyIds, _signatures: signatures, _signatureBlock: signatureBlock
     )      
   }

--- a/transactions/execute_action.cdc
+++ b/transactions/execute_action.cdc
@@ -1,15 +1,26 @@
 import DAOTreasury from "../contracts/DAOTreasury.cdc"
+import MyMultiSig from "../contracts/MyMultiSig.cdc"
 
-transaction(treasuryAddr: Address, actionUUID: UInt64) {
+transaction(treasuryAddr: Address, actionUUID: UInt64, message: String, keyIds: [UInt64], signatures: [String], signatureBlock: UInt64) {
 
-  let Treasury: &DAOTreasury.Treasury{DAOTreasury.TreasuryPublic}
+  let treasury: &DAOTreasury.Treasury{DAOTreasury.TreasuryPublic}
+  let messageSignaturePayload: MyMultiSig.MessageSignaturePayload
   
   prepare(signer: AuthAccount) {
-    self.Treasury = getAccount(treasuryAddr).getCapability(DAOTreasury.TreasuryPublicPath)
+    self.treasury = getAccount(treasuryAddr).getCapability(DAOTreasury.TreasuryPublicPath)
                     .borrow<&DAOTreasury.Treasury{DAOTreasury.TreasuryPublic}>()
-                    ?? panic("A DAOTreasury doesn't exist here.")        
+                    ?? panic("A DAOTreasury doesn't exist here.")
+    var _keyIds: [Int] = []
+
+    for keyId in keyIds {
+        _keyIds.append(Int(keyId))
+    }
+
+    self.messageSignaturePayload = MyMultiSig.MessageSignaturePayload(
+        _signingAddr: signer.address, _message: message, _keyIds: _keyIds, _signatures: signatures, _signatureBlock: signatureBlock
+    )      
   }
   execute {
-    self.Treasury.executeAction(actionUUID: actionUUID)
+    self.treasury.executeAction(actionUUID: actionUUID, signaturePayload: self.messageSignaturePayload)
   }
 }

--- a/transactions/propose_fungible_token_transfer.cdc
+++ b/transactions/propose_fungible_token_transfer.cdc
@@ -1,21 +1,21 @@
-import TreasuryActions from "../contracts/TreasuryActions.cdc"
-import DAOTreasury from "../contracts/DAOTreasury.cdc"
+import TreasuryActionsV2 from "../contracts/TreasuryActions.cdc"
+import DAOTreasuryV2 from "../contracts/DAOTreasury.cdc"
 import FungibleToken from "../contracts/core/FungibleToken.cdc"
-import MyMultiSig from "../contracts/MyMultiSig.cdc"
+import MyMultiSigV2 from "../contracts/MyMultiSig.cdc"
 
 transaction(treasuryAddr: Address, recipientAddr: Address, amount: UFix64, message: String, keyIds: [UInt64], signatures: [String], signatureBlock: UInt64) {
 
-  let treasury: &DAOTreasury.Treasury{DAOTreasury.TreasuryPublic}
+  let treasury: &DAOTreasuryV2.Treasury{DAOTreasuryV2.TreasuryPublic}
   let recipientVault: Capability<&{FungibleToken.Receiver}>
-  let action: AnyStruct{MyMultiSig.Action}
-  let messageSignaturePayload: MyMultiSig.MessageSignaturePayload
+  let action: AnyStruct{MyMultiSigV2.Action}
+  let messageSignaturePayload: MyMultiSigV2.MessageSignaturePayload
   
   prepare(signer: AuthAccount) {
-    self.treasury = getAccount(treasuryAddr).getCapability(DAOTreasury.TreasuryPublicPath)
-                    .borrow<&DAOTreasury.Treasury{DAOTreasury.TreasuryPublic}>()
-                    ?? panic("A DAOTreasury doesn't exist here.")
+    self.treasury = getAccount(treasuryAddr).getCapability(DAOTreasuryV2.TreasuryPublicPath)
+                    .borrow<&DAOTreasuryV2.Treasury{DAOTreasuryV2.TreasuryPublic}>()
+                    ?? panic("A DAOTreasuryV2 doesn't exist here.")
     self.recipientVault = getAccount(recipientAddr).getCapability<&{FungibleToken.Receiver}>(/public/flowTokenReceiver)
-    self.action = TreasuryActions.TransferToken(_recipientVault: self.recipientVault, _amount: amount, _proposer: signer.address)
+    self.action = TreasuryActionsV2.TransferToken(_recipientVault: self.recipientVault, _amount: amount, _proposer: signer.address)
 
     var _keyIds: [Int] = []
 
@@ -23,7 +23,7 @@ transaction(treasuryAddr: Address, recipientAddr: Address, amount: UFix64, messa
         _keyIds.append(Int(keyId))
     }
 
-    self.messageSignaturePayload = MyMultiSig.MessageSignaturePayload(
+    self.messageSignaturePayload = MyMultiSigV2.MessageSignaturePayload(
         _signingAddr: signer.address, _message: message, _keyIds: _keyIds, _signatures: signatures, _signatureBlock: signatureBlock
     )
   }

--- a/transactions/propose_fungible_token_transfer_to_treasury.cdc
+++ b/transactions/propose_fungible_token_transfer_to_treasury.cdc
@@ -1,24 +1,24 @@
-import TreasuryActions from "../contracts/TreasuryActions.cdc"
-import DAOTreasury from "../contracts/DAOTreasury.cdc"
+import TreasuryActionsV2 from "../contracts/TreasuryActions.cdc"
+import DAOTreasuryV2 from "../contracts/DAOTreasury.cdc"
 import FungibleToken from "../contracts/core/FungibleToken.cdc"
-import MyMultiSig from "../contracts/MyMultiSig.cdc"
+import MyMultiSigV2 from "../contracts/MyMultiSig.cdc"
 
-// Proposed ACTION: Transfer `amount` FlowToken from the DAOTreasury
+// Proposed ACTION: Transfer `amount` FlowToken from the DAOTreasuryV2
 // at `treasuryAddr` to `recipientAddr`
 
 transaction(treasuryAddr: Address, recipientAddr: Address, identifier: String, amount: UFix64, message: String, keyIds: [UInt64], signatures: [String], signatureBlock: UInt64) {
 
-  let treasury: &DAOTreasury.Treasury{DAOTreasury.TreasuryPublic}
-  let recipientTreasury: Capability<&{DAOTreasury.TreasuryPublic}>
-  let action: AnyStruct{MyMultiSig.Action}
-  let messageSignaturePayload: MyMultiSig.MessageSignaturePayload
+  let treasury: &DAOTreasuryV2.Treasury{DAOTreasuryV2.TreasuryPublic}
+  let recipientTreasury: Capability<&{DAOTreasuryV2.TreasuryPublic}>
+  let action: AnyStruct{MyMultiSigV2.Action}
+  let messageSignaturePayload: MyMultiSigV2.MessageSignaturePayload
   
   prepare(signer: AuthAccount) {
-    self.treasury = getAccount(treasuryAddr).getCapability(DAOTreasury.TreasuryPublicPath)
-                    .borrow<&DAOTreasury.Treasury{DAOTreasury.TreasuryPublic}>()
-                    ?? panic("A DAOTreasury doesn't exist at the treasuryAddr")
-    self.recipientTreasury = getAccount(recipientAddr).getCapability<&{DAOTreasury.TreasuryPublic}>(DAOTreasury.TreasuryPublicPath)
-    self.action = TreasuryActions.TransferTokenToTreasury(_recipientTreasury: self.recipientTreasury, _identifier: identifier, _amount: amount, _proposer: signer.address)
+    self.treasury = getAccount(treasuryAddr).getCapability(DAOTreasuryV2.TreasuryPublicPath)
+                    .borrow<&DAOTreasuryV2.Treasury{DAOTreasuryV2.TreasuryPublic}>()
+                    ?? panic("A DAOTreasuryV2 doesn't exist at the treasuryAddr")
+    self.recipientTreasury = getAccount(recipientAddr).getCapability<&{DAOTreasuryV2.TreasuryPublic}>(DAOTreasuryV2.TreasuryPublicPath)
+    self.action = TreasuryActionsV2.TransferTokenToTreasury(_recipientTreasury: self.recipientTreasury, _identifier: identifier, _amount: amount, _proposer: signer.address)
 
     var _keyIds: [Int] = []
 
@@ -26,7 +26,7 @@ transaction(treasuryAddr: Address, recipientAddr: Address, identifier: String, a
         _keyIds.append(Int(keyId))
     }
 
-    self.messageSignaturePayload = MyMultiSig.MessageSignaturePayload(
+    self.messageSignaturePayload = MyMultiSigV2.MessageSignaturePayload(
         _signingAddr: signer.address, _message: message, _keyIds: _keyIds, _signatures: signatures, _signatureBlock: signatureBlock
     )
   }

--- a/transactions/propose_fungible_token_transfer_to_treasury.cdc
+++ b/transactions/propose_fungible_token_transfer_to_treasury.cdc
@@ -6,19 +6,31 @@ import MyMultiSig from "../contracts/MyMultiSig.cdc"
 // Proposed ACTION: Transfer `amount` FlowToken from the DAOTreasury
 // at `treasuryAddr` to `recipientAddr`
 
-transaction(treasuryAddr: Address, recipientAddr: Address, identifier: String, amount: UFix64) {
+transaction(treasuryAddr: Address, recipientAddr: Address, identifier: String, amount: UFix64, message: String, keyIds: [UInt64], signatures: [String], signatureBlock: UInt64) {
 
-  let Treasury: &DAOTreasury.Treasury{DAOTreasury.TreasuryPublic}
-  let RecipientTreasury: Capability<&{DAOTreasury.TreasuryPublic}>
+  let treasury: &DAOTreasury.Treasury{DAOTreasury.TreasuryPublic}
+  let recipientTreasury: Capability<&{DAOTreasury.TreasuryPublic}>
+  let action: AnyStruct{MyMultiSig.Action}
+  let messageSignaturePayload: MyMultiSig.MessageSignaturePayload
   
   prepare(signer: AuthAccount) {
-    self.Treasury = getAccount(treasuryAddr).getCapability(DAOTreasury.TreasuryPublicPath)
+    self.treasury = getAccount(treasuryAddr).getCapability(DAOTreasury.TreasuryPublicPath)
                     .borrow<&DAOTreasury.Treasury{DAOTreasury.TreasuryPublic}>()
                     ?? panic("A DAOTreasury doesn't exist at the treasuryAddr")
-    self.RecipientTreasury = getAccount(recipientAddr).getCapability<&{DAOTreasury.TreasuryPublic}>(DAOTreasury.TreasuryPublicPath)
+    self.recipientTreasury = getAccount(recipientAddr).getCapability<&{DAOTreasury.TreasuryPublic}>(DAOTreasury.TreasuryPublicPath)
+    self.action = TreasuryActions.TransferTokenToTreasury(_recipientTreasury: self.recipientTreasury, _identifier: identifier, _amount: amount, _proposer: signer.address)
+
+    var _keyIds: [Int] = []
+
+    for keyId in keyIds {
+        _keyIds.append(Int(keyId))
+    }
+
+    self.messageSignaturePayload = MyMultiSig.MessageSignaturePayload(
+        _signingAddr: signer.address, _message: message, _keyIds: _keyIds, _signatures: signatures, _signatureBlock: signatureBlock
+    )
   }
   execute {
-    let action = TreasuryActions.TransferTokenToTreasury(_recipientTreasury: self.RecipientTreasury, _identifier: identifier, _amount: amount)
-    self.Treasury.proposeAction(action: action)
+    self.treasury.proposeAction(action: self.action, signaturePayload: self.messageSignaturePayload)
   }
 }

--- a/transactions/propose_non_fungible_token_transfer.cdc
+++ b/transactions/propose_non_fungible_token_transfer.cdc
@@ -1,22 +1,22 @@
-import TreasuryActions from "../contracts/TreasuryActions.cdc"
-import DAOTreasury from "../contracts/DAOTreasury.cdc"
+import TreasuryActionsV2 from "../contracts/TreasuryActions.cdc"
+import DAOTreasuryV2 from "../contracts/DAOTreasury.cdc"
 import NonFungibleToken from "../contracts/core/NonFungibleToken.cdc"
-import MyMultiSig from "../contracts/MyMultiSig.cdc"
+import MyMultiSigV2 from "../contracts/MyMultiSig.cdc"
 import ExampleNFT from "../contracts/core/ExampleNFT.cdc"
 
 transaction(treasuryAddr: Address, recipientAddr: Address, id: UInt64, message: String, keyIds: [UInt64], signatures: [String], signatureBlock: UInt64) {
 
-  let treasury: &DAOTreasury.Treasury{DAOTreasury.TreasuryPublic}
+  let treasury: &DAOTreasuryV2.Treasury{DAOTreasuryV2.TreasuryPublic}
   let recipientCollection: Capability<&{NonFungibleToken.CollectionPublic}>
-  let action: AnyStruct{MyMultiSig.Action}
-  let messageSignaturePayload: MyMultiSig.MessageSignaturePayload
+  let action: AnyStruct{MyMultiSigV2.Action}
+  let messageSignaturePayload: MyMultiSigV2.MessageSignaturePayload
   
   prepare(signer: AuthAccount) {
-    self.treasury = getAccount(treasuryAddr).getCapability(DAOTreasury.TreasuryPublicPath)
-                    .borrow<&DAOTreasury.Treasury{DAOTreasury.TreasuryPublic}>()
-                    ?? panic("A DAOTreasury doesn't exist here.")
+    self.treasury = getAccount(treasuryAddr).getCapability(DAOTreasuryV2.TreasuryPublicPath)
+                    .borrow<&DAOTreasuryV2.Treasury{DAOTreasuryV2.TreasuryPublic}>()
+                    ?? panic("A DAOTreasuryV2 doesn't exist here.")
     self.recipientCollection = getAccount(recipientAddr).getCapability<&{NonFungibleToken.CollectionPublic}>(ExampleNFT.CollectionPublicPath)
-    self.action = TreasuryActions.TransferNFT(_recipientCollection: self.recipientCollection, _nftID: id, _proposer: signer.address)
+    self.action = TreasuryActionsV2.TransferNFT(_recipientCollection: self.recipientCollection, _nftID: id, _proposer: signer.address)
     
     var _keyIds: [Int] = []
 
@@ -24,7 +24,7 @@ transaction(treasuryAddr: Address, recipientAddr: Address, id: UInt64, message: 
         _keyIds.append(Int(keyId))
     }
 
-    self.messageSignaturePayload = MyMultiSig.MessageSignaturePayload(
+    self.messageSignaturePayload = MyMultiSigV2.MessageSignaturePayload(
         _signingAddr: signer.address, _message: message, _keyIds: _keyIds, _signatures: signatures, _signatureBlock: signatureBlock
     )
   }

--- a/transactions/propose_non_fungible_token_transfer_to_treasury.cdc
+++ b/transactions/propose_non_fungible_token_transfer_to_treasury.cdc
@@ -1,27 +1,27 @@
-import TreasuryActions from "../contracts/TreasuryActions.cdc"
-import DAOTreasury from "../contracts/DAOTreasury.cdc"
+import TreasuryActionsV2 from "../contracts/TreasuryActions.cdc"
+import DAOTreasuryV2 from "../contracts/DAOTreasury.cdc"
 import NonFungibleToken from "../contracts/core/NonFungibleToken.cdc"
-import MyMultiSig from "../contracts/MyMultiSig.cdc"
+import MyMultiSigV2 from "../contracts/MyMultiSig.cdc"
 import ExampleNFT from "../contracts/core/ExampleNFT.cdc"
 
 // An example of proposing an action.
 //
-// Proposed ACTION: Transfer ExampleNFT with ID `id` from the DAOTreasury
+// Proposed ACTION: Transfer ExampleNFT with ID `id` from the DAOTreasuryV2
 // at `treasuryAddr` to `recipientAddr`
 
 transaction(treasuryAddr: Address, recipientAddr: Address, identifier: String, id: UInt64, message: String, keyIds: [UInt64], signatures: [String], signatureBlock: UInt64) {
 
-  let treasury: &DAOTreasury.Treasury{DAOTreasury.TreasuryPublic}
-  let recipientTreasury: Capability<&{DAOTreasury.TreasuryPublic}>
-  let action: AnyStruct{MyMultiSig.Action}
-  let messageSignaturePayload: MyMultiSig.MessageSignaturePayload
+  let treasury: &DAOTreasuryV2.Treasury{DAOTreasuryV2.TreasuryPublic}
+  let recipientTreasury: Capability<&{DAOTreasuryV2.TreasuryPublic}>
+  let action: AnyStruct{MyMultiSigV2.Action}
+  let messageSignaturePayload: MyMultiSigV2.MessageSignaturePayload
   
   prepare(signer: AuthAccount) {
-    self.treasury = getAccount(treasuryAddr).getCapability(DAOTreasury.TreasuryPublicPath)
-                    .borrow<&DAOTreasury.Treasury{DAOTreasury.TreasuryPublic}>()
-                    ?? panic("A DAOTreasury doesn't exist here.")
-    self.recipientTreasury = getAccount(recipientAddr).getCapability<&{DAOTreasury.TreasuryPublic}>(DAOTreasury.TreasuryPublicPath)
-    self.action = TreasuryActions.TransferNFTToTreasury(_recipientTreasury: self.recipientTreasury, _identifier: identifier, _nftID: id, _proposer: signer.address)
+    self.treasury = getAccount(treasuryAddr).getCapability(DAOTreasuryV2.TreasuryPublicPath)
+                    .borrow<&DAOTreasuryV2.Treasury{DAOTreasuryV2.TreasuryPublic}>()
+                    ?? panic("A DAOTreasuryV2 doesn't exist here.")
+    self.recipientTreasury = getAccount(recipientAddr).getCapability<&{DAOTreasuryV2.TreasuryPublic}>(DAOTreasuryV2.TreasuryPublicPath)
+    self.action = TreasuryActionsV2.TransferNFTToTreasury(_recipientTreasury: self.recipientTreasury, _identifier: identifier, _nftID: id, _proposer: signer.address)
     
     var _keyIds: [Int] = []
 
@@ -29,7 +29,7 @@ transaction(treasuryAddr: Address, recipientAddr: Address, identifier: String, i
         _keyIds.append(Int(keyId))
     }
 
-    self.messageSignaturePayload = MyMultiSig.MessageSignaturePayload(
+    self.messageSignaturePayload = MyMultiSigV2.MessageSignaturePayload(
         _signingAddr: signer.address, _message: message, _keyIds: _keyIds, _signatures: signatures, _signatureBlock: signatureBlock
     )
   }

--- a/transactions/remove_signer.cdc
+++ b/transactions/remove_signer.cdc
@@ -1,16 +1,28 @@
 import DAOTreasury from "../contracts/DAOTreasury.cdc"
 import TreasuryActions from "../contracts/TreasuryActions.cdc"
+import MyMultiSig from "../contracts/MyMultiSig.cdc"
 
-transaction(signerToBeRemoved: Address) {
+transaction(signerToBeRemoved: Address, message: String, keyIds: [UInt64], signatures: [String], signatureBlock: UInt64) {
   
-  let Treasury: &DAOTreasury.Treasury{DAOTreasury.TreasuryPublic}
+  let treasury: &DAOTreasury.Treasury{DAOTreasury.TreasuryPublic}
+  let action: AnyStruct{MyMultiSig.Action}
+  let messageSignaturePayload: MyMultiSig.MessageSignaturePayload
 
   prepare(signer: AuthAccount) {
-    self.Treasury = signer.borrow<&DAOTreasury.Treasury>(from: DAOTreasury.TreasuryStoragePath)
+    self.treasury = signer.borrow<&DAOTreasury.Treasury>(from: DAOTreasury.TreasuryStoragePath)
                     ?? panic("Could not borrow the DAOTreasury")
+    self.action = TreasuryActions.RemoveSigner(signerToBeRemoved, signer.address)
+    var _keyIds: [Int] = []
+
+    for keyId in keyIds {
+        _keyIds.append(Int(keyId))
+    }
+
+    self.messageSignaturePayload = MyMultiSig.MessageSignaturePayload(
+        _signingAddr: signer.address, _message: message, _keyIds: _keyIds, _signatures: signatures, _signatureBlock: signatureBlock
+    )
   }
   execute {
-    let action = TreasuryActions.RemoveSigner(_signer: signerToBeRemoved)
-    self.Treasury.proposeAction(action: action)
+    self.treasury.proposeAction(action: self.action, signaturePayload: self.messageSignaturePayload)
   }
 }

--- a/transactions/remove_signer.cdc
+++ b/transactions/remove_signer.cdc
@@ -1,25 +1,25 @@
-import DAOTreasury from "../contracts/DAOTreasury.cdc"
-import TreasuryActions from "../contracts/TreasuryActions.cdc"
-import MyMultiSig from "../contracts/MyMultiSig.cdc"
+import DAOTreasuryV2 from "../contracts/DAOTreasury.cdc"
+import TreasuryActionsV2 from "../contracts/TreasuryActions.cdc"
+import MyMultiSigV2 from "../contracts/MyMultiSig.cdc"
 
 transaction(treasuryAddr: Address, signerToBeRemoved: Address, message: String, keyIds: [UInt64], signatures: [String], signatureBlock: UInt64) {
   
-  let treasury: &DAOTreasury.Treasury{DAOTreasury.TreasuryPublic}
-  let action: AnyStruct{MyMultiSig.Action}
-  let messageSignaturePayload: MyMultiSig.MessageSignaturePayload
+  let treasury: &DAOTreasuryV2.Treasury{DAOTreasuryV2.TreasuryPublic}
+  let action: AnyStruct{MyMultiSigV2.Action}
+  let messageSignaturePayload: MyMultiSigV2.MessageSignaturePayload
 
   prepare(signer: AuthAccount) {
-    self.treasury = getAccount(treasuryAddr).getCapability(DAOTreasury.TreasuryPublicPath)
-                    .borrow<&DAOTreasury.Treasury{DAOTreasury.TreasuryPublic}>()
-                    ?? panic("A DAOTreasury doesn't exist here.")
-    self.action = TreasuryActions.RemoveSigner(_signer: signerToBeRemoved, _proposer: signer.address)
+    self.treasury = getAccount(treasuryAddr).getCapability(DAOTreasuryV2.TreasuryPublicPath)
+                    .borrow<&DAOTreasuryV2.Treasury{DAOTreasuryV2.TreasuryPublic}>()
+                    ?? panic("A DAOTreasuryV2 doesn't exist here.")
+    self.action = TreasuryActionsV2.RemoveSigner(_signer: signerToBeRemoved, _proposer: signer.address)
     var _keyIds: [Int] = []
 
     for keyId in keyIds {
         _keyIds.append(Int(keyId))
     }
 
-    self.messageSignaturePayload = MyMultiSig.MessageSignaturePayload(
+    self.messageSignaturePayload = MyMultiSigV2.MessageSignaturePayload(
         _signingAddr: signer.address, _message: message, _keyIds: _keyIds, _signatures: signatures, _signatureBlock: signatureBlock
     )
   }

--- a/transactions/remove_signer.cdc
+++ b/transactions/remove_signer.cdc
@@ -2,15 +2,16 @@ import DAOTreasury from "../contracts/DAOTreasury.cdc"
 import TreasuryActions from "../contracts/TreasuryActions.cdc"
 import MyMultiSig from "../contracts/MyMultiSig.cdc"
 
-transaction(signerToBeRemoved: Address, message: String, keyIds: [UInt64], signatures: [String], signatureBlock: UInt64) {
+transaction(treasuryAddr: Address, signerToBeRemoved: Address, message: String, keyIds: [UInt64], signatures: [String], signatureBlock: UInt64) {
   
   let treasury: &DAOTreasury.Treasury{DAOTreasury.TreasuryPublic}
   let action: AnyStruct{MyMultiSig.Action}
   let messageSignaturePayload: MyMultiSig.MessageSignaturePayload
 
   prepare(signer: AuthAccount) {
-    self.treasury = signer.borrow<&DAOTreasury.Treasury>(from: DAOTreasury.TreasuryStoragePath)
-                    ?? panic("Could not borrow the DAOTreasury")
+        self.treasury = getAccount(treasuryAddr).getCapability(DAOTreasury.TreasuryPublicPath)
+                    .borrow<&DAOTreasury.Treasury{DAOTreasury.TreasuryPublic}>()
+                    ?? panic("A DAOTreasury doesn't exist here.")
     self.action = TreasuryActions.RemoveSigner(signerToBeRemoved, signer.address)
     var _keyIds: [Int] = []
 

--- a/transactions/send_collection_to_treasury.cdc
+++ b/transactions/send_collection_to_treasury.cdc
@@ -1,7 +1,7 @@
 import NonFungibleToken from "../contracts/core/NonFungibleToken.cdc"
 import ExampleNFT from "../contracts/core/ExampleNFT.cdc"
-import DAOTreasury from "../contracts/DAOTreasury.cdc"
-import MyMultiSig from "../contracts/MyMultiSig.cdc"
+import DAOTreasuryV2 from "../contracts/DAOTreasury.cdc"
+import MyMultiSigV2 from "../contracts/MyMultiSig.cdc"
 
 transaction(treasuryAddr: Address, message: String, keyIds: [UInt64], signatures: [String], signatureBlock: UInt64) {
 
@@ -12,9 +12,9 @@ transaction(treasuryAddr: Address, message: String, keyIds: [UInt64], signatures
             .borrow<&ExampleNFT.Collection>(from: ExampleNFT.CollectionStoragePath)
             ?? panic("Could not borrow a reference to the owner's collection")
 
-        let treasury = getAccount(treasuryAddr).getCapability(DAOTreasury.TreasuryPublicPath)
-                    .borrow<&DAOTreasury.Treasury{DAOTreasury.TreasuryPublic}>()
-                    ?? panic("A DAOTreasury doesn't exist here.")
+        let treasury = getAccount(treasuryAddr).getCapability(DAOTreasuryV2.TreasuryPublicPath)
+                    .borrow<&DAOTreasuryV2.Treasury{DAOTreasuryV2.TreasuryPublic}>()
+                    ?? panic("A DAOTreasuryV2 doesn't exist here.")
 
         let collection <- ExampleNFT.createEmptyCollection()
 
@@ -24,7 +24,7 @@ transaction(treasuryAddr: Address, message: String, keyIds: [UInt64], signatures
             _keyIds.append(Int(keyId))
         }
 
-        let messageSignaturePayload = MyMultiSig.MessageSignaturePayload(
+        let messageSignaturePayload = MyMultiSigV2.MessageSignaturePayload(
             _signingAddr: signer.address, _message: message, _keyIds: _keyIds, _signatures: signatures, _signatureBlock: signatureBlock
         )
         // Deposit the NFT in the treasury's collection

--- a/transactions/send_flow_to_treasury.cdc
+++ b/transactions/send_flow_to_treasury.cdc
@@ -1,4 +1,4 @@
-import DAOTreasury from "../contracts/DAOTreasury.cdc"
+import DAOTreasuryV2 from "../contracts/DAOTreasury.cdc"
 import FungibleToken from "../contracts/core/FungibleToken.cdc"
 
 transaction(treasuryAddr: Address, amount: UFix64) {
@@ -8,9 +8,9 @@ transaction(treasuryAddr: Address, amount: UFix64) {
       let vault = signer.borrow<&FungibleToken.Vault>(from: /storage/flowTokenVault)!
       let tokens <- vault.withdraw(amount: amount)
 
-      let treasury = getAccount(treasuryAddr).getCapability(DAOTreasury.TreasuryPublicPath)
-                  .borrow<&DAOTreasury.Treasury{DAOTreasury.TreasuryPublic}>()
-                  ?? panic("A DAOTreasury doesn't exist here.")
+      let treasury = getAccount(treasuryAddr).getCapability(DAOTreasuryV2.TreasuryPublicPath)
+                  .borrow<&DAOTreasuryV2.Treasury{DAOTreasuryV2.TreasuryPublic}>()
+                  ?? panic("A DAOTreasuryV2 doesn't exist here.")
 
       let identifier: String = vault.getType().identifier
 

--- a/transactions/send_nft_to_treasury.cdc
+++ b/transactions/send_nft_to_treasury.cdc
@@ -1,7 +1,7 @@
 import NonFungibleToken from "../contracts/core/NonFungibleToken.cdc"
 import ExampleNFT from "../contracts/core/ExampleNFT.cdc"
-import DAOTreasury from "../contracts/DAOTreasury.cdc"
-import MyMultiSig from "../contracts/MyMultiSig.cdc"
+import DAOTreasuryV2 from "../contracts/DAOTreasury.cdc"
+import MyMultiSigV2 from "../contracts/MyMultiSig.cdc"
 
 // This transaction is for transferring and NFT from
 // one account to another
@@ -13,9 +13,9 @@ transaction(treasuryAddr: Address, withdrawID: UInt64) {
             .borrow<&ExampleNFT.Collection>(from: ExampleNFT.CollectionStoragePath)
             ?? panic("Could not borrow a reference to the owner's collection")
 
-        let treasury = getAccount(treasuryAddr).getCapability(DAOTreasury.TreasuryPublicPath)
-                    .borrow<&DAOTreasury.Treasury{DAOTreasury.TreasuryPublic}>()
-                    ?? panic("A DAOTreasury doesn't exist here.")
+        let treasury = getAccount(treasuryAddr).getCapability(DAOTreasuryV2.TreasuryPublicPath)
+                    .borrow<&DAOTreasuryV2.Treasury{DAOTreasuryV2.TreasuryPublic}>()
+                    ?? panic("A DAOTreasuryV2 doesn't exist here.")
 
         // withdraw the NFT from the owner's collection
         let nft <- collectionRef.withdraw(withdrawID: withdrawID)

--- a/transactions/signer_approve.cdc
+++ b/transactions/signer_approve.cdc
@@ -1,17 +1,17 @@
-import DAOTreasury from "../contracts/DAOTreasury.cdc"
-import MyMultiSig from "../contracts/MyMultiSig.cdc"
+import DAOTreasuryV2 from "../contracts/DAOTreasury.cdc"
+import MyMultiSigV2 from "../contracts/MyMultiSig.cdc"
 
 transaction(treasuryAddr: Address, actionUUID: UInt64, message: String, keyIds: [UInt64], signatures: [String], signatureBlock: UInt64) {
 
   var isValid: Bool
-  let action: &MyMultiSig.MultiSignAction 
-  let messageSignaturePayload: MyMultiSig.MessageSignaturePayload
+  let action: &MyMultiSigV2.MultiSignAction 
+  let messageSignaturePayload: MyMultiSigV2.MessageSignaturePayload
 
   prepare(signer: AuthAccount) {
     self.isValid = false
-    let treasury = getAccount(treasuryAddr).getCapability(DAOTreasury.TreasuryPublicPath)
-                    .borrow<&DAOTreasury.Treasury{DAOTreasury.TreasuryPublic}>()
-                    ?? panic("A DAOTreasury doesn't exist here.")
+    let treasury = getAccount(treasuryAddr).getCapability(DAOTreasuryV2.TreasuryPublicPath)
+                    .borrow<&DAOTreasuryV2.Treasury{DAOTreasuryV2.TreasuryPublic}>()
+                    ?? panic("A DAOTreasuryV2 doesn't exist here.")
 
     let manager = treasury.borrowManagerPublic()
     self.action = manager.borrowAction(actionUUID: actionUUID)
@@ -22,7 +22,7 @@ transaction(treasuryAddr: Address, actionUUID: UInt64, message: String, keyIds: 
       _keyIds.append(Int(keyId))
     }
 
-    self.messageSignaturePayload = MyMultiSig.MessageSignaturePayload(
+    self.messageSignaturePayload = MyMultiSigV2.MessageSignaturePayload(
       _signingAddr: signer.address, _message: message, _keyIds: _keyIds, _signatures: signatures, _signatureBlock: signatureBlock
     )
 

--- a/transactions/signer_revoke.cdc
+++ b/transactions/signer_revoke.cdc
@@ -1,17 +1,17 @@
-import DAOTreasury from "../contracts/DAOTreasury.cdc"
-import MyMultiSig from "../contracts/MyMultiSig.cdc"
+import DAOTreasuryV2 from "../contracts/DAOTreasury.cdc"
+import MyMultiSigV2 from "../contracts/MyMultiSig.cdc"
 
 transaction(treasuryAddr: Address, actionUUID: UInt64, message: String, keyIds: [UInt64], signatures: [String], signatureBlock: UInt64) {
 
   var isValid: Bool
-  var action: &MyMultiSig.MultiSignAction
-  var messageSignaturePayload: MyMultiSig.MessageSignaturePayload
+  var action: &MyMultiSigV2.MultiSignAction
+  var messageSignaturePayload: MyMultiSigV2.MessageSignaturePayload
   
   prepare(signer: AuthAccount) {
     self.isValid = false
-    let treasury = getAccount(treasuryAddr).getCapability(DAOTreasury.TreasuryPublicPath)
-                    .borrow<&DAOTreasury.Treasury{DAOTreasury.TreasuryPublic}>()
-                    ?? panic("A DAOTreasury doesn't exist here.")
+    let treasury = getAccount(treasuryAddr).getCapability(DAOTreasuryV2.TreasuryPublicPath)
+                    .borrow<&DAOTreasuryV2.Treasury{DAOTreasuryV2.TreasuryPublic}>()
+                    ?? panic("A DAOTreasuryV2 doesn't exist here.")
 
     let manager = treasury.borrowManagerPublic()
     self.action = manager.borrowAction(actionUUID: actionUUID)
@@ -22,7 +22,7 @@ transaction(treasuryAddr: Address, actionUUID: UInt64, message: String, keyIds: 
       _keyIds.append(Int(keyId))
     }
 
-    self.messageSignaturePayload = MyMultiSig.MessageSignaturePayload(
+    self.messageSignaturePayload = MyMultiSigV2.MessageSignaturePayload(
       _signingAddr: signer.address, _message: message, _keyIds: _keyIds, _signatures: signatures, _signatureBlock: signatureBlock
     )
 

--- a/transactions/update_threshold.cdc
+++ b/transactions/update_threshold.cdc
@@ -2,15 +2,16 @@ import DAOTreasury from "../contracts/DAOTreasury.cdc"
 import TreasuryActions from "../contracts/TreasuryActions.cdc"
 import MyMultiSig from "../contracts/MyMultiSig.cdc"
 
-transaction(newThreshold: UInt64, message: String, keyIds: [UInt64], signatures: [String], signatureBlock: UInt64) {
+transaction(treasuryAddr: Address, newThreshold: UInt64, message: String, keyIds: [UInt64], signatures: [String], signatureBlock: UInt64) {
   
   let treasury: &DAOTreasury.Treasury{DAOTreasury.TreasuryPublic}
   let action: AnyStruct{MyMultiSig.Action}
   let messageSignaturePayload: MyMultiSig.MessageSignaturePayload
 
   prepare(signer: AuthAccount) {
-    self.treasury = signer.borrow<&DAOTreasury.Treasury>(from: DAOTreasury.TreasuryStoragePath)
-                    ?? panic("Could not borrow the DAOTreasury")
+        self.treasury = getAccount(treasuryAddr).getCapability(DAOTreasury.TreasuryPublicPath)
+                    .borrow<&DAOTreasury.Treasury{DAOTreasury.TreasuryPublic}>()
+                    ?? panic("A DAOTreasury doesn't exist here.")
     self.action = TreasuryActions.UpdateThreshold(newThreshold, signer.address)
 
     var _keyIds: [Int] = []

--- a/transactions/update_threshold.cdc
+++ b/transactions/update_threshold.cdc
@@ -1,18 +1,18 @@
-import DAOTreasury from "../contracts/DAOTreasury.cdc"
-import TreasuryActions from "../contracts/TreasuryActions.cdc"
-import MyMultiSig from "../contracts/MyMultiSig.cdc"
+import DAOTreasuryV2 from "../contracts/DAOTreasury.cdc"
+import TreasuryActionsV2 from "../contracts/TreasuryActions.cdc"
+import MyMultiSigV2 from "../contracts/MyMultiSig.cdc"
 
 transaction(treasuryAddr: Address, newThreshold: UInt64, message: String, keyIds: [UInt64], signatures: [String], signatureBlock: UInt64) {
   
-  let treasury: &DAOTreasury.Treasury{DAOTreasury.TreasuryPublic}
-  let action: AnyStruct{MyMultiSig.Action}
-  let messageSignaturePayload: MyMultiSig.MessageSignaturePayload
+  let treasury: &DAOTreasuryV2.Treasury{DAOTreasuryV2.TreasuryPublic}
+  let action: AnyStruct{MyMultiSigV2.Action}
+  let messageSignaturePayload: MyMultiSigV2.MessageSignaturePayload
 
   prepare(signer: AuthAccount) {
-    self.treasury = getAccount(treasuryAddr).getCapability(DAOTreasury.TreasuryPublicPath)
-                    .borrow<&DAOTreasury.Treasury{DAOTreasury.TreasuryPublic}>()
-                    ?? panic("A DAOTreasury doesn't exist here.")
-    self.action = TreasuryActions.UpdateThreshold(_threshold: newThreshold, _proposer: signer.address)
+    self.treasury = getAccount(treasuryAddr).getCapability(DAOTreasuryV2.TreasuryPublicPath)
+                    .borrow<&DAOTreasuryV2.Treasury{DAOTreasuryV2.TreasuryPublic}>()
+                    ?? panic("A DAOTreasuryV2 doesn't exist here.")
+    self.action = TreasuryActionsV2.UpdateThreshold(_threshold: newThreshold, _proposer: signer.address)
 
     var _keyIds: [Int] = []
 
@@ -20,7 +20,7 @@ transaction(treasuryAddr: Address, newThreshold: UInt64, message: String, keyIds
         _keyIds.append(Int(keyId))
     }
 
-    self.messageSignaturePayload = MyMultiSig.MessageSignaturePayload(
+    self.messageSignaturePayload = MyMultiSigV2.MessageSignaturePayload(
         _signingAddr: signer.address, _message: message, _keyIds: _keyIds, _signatures: signatures, _signatureBlock: signatureBlock
     )
   }

--- a/transactions/update_threshold.cdc
+++ b/transactions/update_threshold.cdc
@@ -1,16 +1,29 @@
 import DAOTreasury from "../contracts/DAOTreasury.cdc"
 import TreasuryActions from "../contracts/TreasuryActions.cdc"
+import MyMultiSig from "../contracts/MyMultiSig.cdc"
 
-transaction(newThreshold: UInt64) {
+transaction(newThreshold: UInt64, message: String, keyIds: [UInt64], signatures: [String], signatureBlock: UInt64) {
   
-  let Treasury: &DAOTreasury.Treasury{DAOTreasury.TreasuryPublic}
+  let treasury: &DAOTreasury.Treasury{DAOTreasury.TreasuryPublic}
+  let action: AnyStruct{MyMultiSig.Action}
+  let messageSignaturePayload: MyMultiSig.MessageSignaturePayload
 
   prepare(signer: AuthAccount) {
-    self.Treasury = signer.borrow<&DAOTreasury.Treasury>(from: DAOTreasury.TreasuryStoragePath)
+    self.treasury = signer.borrow<&DAOTreasury.Treasury>(from: DAOTreasury.TreasuryStoragePath)
                     ?? panic("Could not borrow the DAOTreasury")
+    self.action = TreasuryActions.UpdateThreshold(newThreshold, signer.address)
+
+    var _keyIds: [Int] = []
+
+    for keyId in keyIds {
+        _keyIds.append(Int(keyId))
+    }
+
+    self.messageSignaturePayload = MyMultiSig.MessageSignaturePayload(
+        _signingAddr: signer.address, _message: message, _keyIds: _keyIds, _signatures: signatures, _signatureBlock: signatureBlock
+    )
   }
   execute {
-    let action = TreasuryActions.UpdateThreshold(_threshold: newThreshold)
-    self.Treasury.proposeAction(action: action)
+    self.treasury.proposeAction(action: self.action, signaturePayload: self.messageSignaturePayload)
   }
 }


### PR DESCRIPTION
Renamed contracts to enable deployment to testnet, V2 added to naming
Updated transactions for adding/removing signer and updating threshold to contain treasuryAddress as parameter, to avoid errors in the future, updated tests and UI accordingly 