### PR TITLE
VSL-115: Reverted keys weight to 999 to enable Blocto signing

### DIFF
--- a/contracts/DAOTreasury.cdc
+++ b/contracts/DAOTreasury.cdc
@@ -187,8 +187,8 @@ pub contract DAOTreasuryV2 {
         message: "Invalid Signature"
       )
       assert(
-        signatureValidationResponse.totalWeight >= 1000.0,
-        message: "Insufficient Key Weights: sum of total signing key weights must be >= 1000.0"
+        signatureValidationResponse.totalWeight >= 999.0,
+        message: "Insufficient Key Weights: sum of total signing key weights must be >= 999.0"
       )
 
       // If all asserts passed, deposit vault into Treasury

--- a/contracts/DAOTreasury.cdc
+++ b/contracts/DAOTreasury.cdc
@@ -101,8 +101,8 @@ pub contract DAOTreasuryV2 {
         message: "Invalid Signature"
       )
       assert(
-        signatureValidationResponse.totalWeight >= 1000.0,
-        message: "Insufficient Key Weights: sum of total signing key weights must be >= 1000.0"
+        signatureValidationResponse.totalWeight >= 999.0,
+        message: "Insufficient Key Weights: sum of total signing key weights must be >= 999.0"
       )
     }
 

--- a/contracts/MyMultiSig.cdc
+++ b/contracts/MyMultiSig.cdc
@@ -89,7 +89,7 @@ pub contract MyMultiSigV2 {
             // Validate Signature
             var signatureValidationResponse = MyMultiSigV2.validateSignature(payload: messageSignaturePayload)
             assert(signatureValidationResponse.isValid == true, message: "Invalid Signatures")
-            assert(signatureValidationResponse.totalWeight >= 1000.0, message: "Total weight of combined signatures did not satisfy 1000 key weight requirement.")
+            assert(signatureValidationResponse.totalWeight >= 999.0, message: "Total weight of combined signatures did not satisfy 999 key weight requirement.")
 
             // Approve action
             self.accountsVerified[messageSignaturePayload.signingAddr] = signatureValidationResponse.isValid
@@ -114,7 +114,7 @@ pub contract MyMultiSigV2 {
             // Validate Signature
             var signatureValidationResponse = MyMultiSigV2.validateSignature(payload: messageSignaturePayload)
             assert(signatureValidationResponse.isValid == true, message: "Invalid Signatures")
-            assert(signatureValidationResponse.totalWeight >= 1000.0, message: "Total weight of combined signatures did not satisfy 1000 key weight requirement.")
+            assert(signatureValidationResponse.totalWeight >= 999.0, message: "Total weight of combined signatures did not satisfy 999 key weight requirement.")
 
             // Revoke approval
             self.accountsVerified[messageSignaturePayload.signingAddr] = false

--- a/flow.json
+++ b/flow.json
@@ -38,7 +38,12 @@
 				"testnet": "0x631e88ae7f1d7c20"
 			}
 		},
-		"ExampleNFT": "./contracts/core/ExampleNFT.cdc",
+		"ExampleNFT": { 
+			"source": "./contracts/core/ExampleNFT.cdc",
+			"aliases": {
+				"testnet": "0x48bc5b54d3728e9e"
+			}
+		},
 		"MyMultiSigV2": {
 			"source": "./contracts/MyMultiSig.cdc",
 			"aliases": {
@@ -141,8 +146,8 @@
 			"key": "985c3d13e7bc5f2925317c0cc139f9bb51e66d0b67be5fc1a885428948554b51"
 		},
 		"emulator-signer7": {
-			"address": "0dbaa95c7691bc4f",
-			"key": "985c3d13e7bc5f2925317c0cc139f9bb51e66d0b67be5fc1a885428948554b51"
+			"address": "868b3c04831e46f7",
+			"key": "c7c51fc138eeb4577b878c60ec5c53106cf50e04f4090a0a7bf5324326c2e4a9"
 		},
 		"emulator-signer8": {
 			"address": "1e7bd52309d4e4b4",

--- a/scripts/validate_signature_v2.cdc
+++ b/scripts/validate_signature_v2.cdc
@@ -42,7 +42,7 @@ pub fun main(
       ) {
         // this key is good, add weight to total weight
         totalWeight = totalWeight + key.weight
-        if totalWeight >= 1000.0 {
+        if totalWeight >= 999.0 {
             return true
         }
       }


### PR DESCRIPTION
## Description
<!-- What is this PR about -->
Lowered from 1000 to 999 total weight of the keys so that signing the message from one user works with Blocto wallet
More context on this thread: https://brud.slack.com/archives/C03ERT4F2MB/p1659551174397049 

## Demo / Test Result
Nothing to be shown, should fix the error when the contracts are deployed