### PR TITLE
VSL-111: Bug fix Owner list is empty after load safe

### DIFF
--- a/packages/client/src/pages/LoadSafe.js
+++ b/packages/client/src/pages/LoadSafe.js
@@ -66,7 +66,6 @@ function LoadSafe({ web3 }) {
   const [safeOwnersValidByAddress, setSafeOwnersValidByAddress] = useState({});
   const { injectedProvider, fetchTreasury, setTreasury, address } = web3;
   const { isAddressValid } = useAddressValidation(injectedProvider);
-
   if (!address) {
     return <WalletPrompt />;
   }
@@ -92,6 +91,7 @@ function LoadSafe({ web3 }) {
         (signerAddr) => ({
           name: "",
           address: signerAddr,
+          verified: true,
         })
       );
 


### PR DESCRIPTION
## Description
This pr fixes the bug reported in ticket https://linear.app/dappercollectives/issue/VSL-111/owner-list-is-empty-after-load-safe
After loading a safe, safe settings page should display safe owners


## Demo / Test Result
<!-- For FE changes, please attach screenshots/gif/video to show case the work -->
<!-- For Bug fix, please attach BEFORE & AFTER -->
<!-- For BE changes, how it's been verified? Unit test / E2E test result -->


https://user-images.githubusercontent.com/7423845/184228535-4d71e3b1-bd5c-4c82-9881-9d3742a22ded.mov


