### PR TITLE
hide remove link when there's only one owner on the list

### DIFF
--- a/packages/client/src/components/SafeSettings.js
+++ b/packages/client/src/components/SafeSettings.js
@@ -450,7 +450,7 @@ function SafeSettings({ address, web3, name, threshold, safeOwners }) {
     proposeRemoveSigner,
   } = web3;
   const verifiedSafeOwners = safeOwners.filter((so) => so.verified);
-  const onlyOneOwnerLeft = verifiedSafeOwners.length === 1;
+  const canRemoveSigner = verifiedSafeOwners.length > threshold;
   const onEditNameSubmit = (newName) => {
     modalContext.closeModal();
     setTreasury(address, { name: newName });
@@ -626,7 +626,7 @@ function SafeSettings({ address, web3, name, threshold, safeOwners }) {
                     ? "Copied"
                     : "Copy Address"}
                 </span>
-                {!onlyOneOwnerLeft && (
+                {canRemoveSigner && (
                   <span
                     className="is-underlined pointer"
                     onClick={() => openRemoveOwnerModal(so)}

--- a/packages/client/src/components/SafeSettings.js
+++ b/packages/client/src/components/SafeSettings.js
@@ -450,6 +450,7 @@ function SafeSettings({ address, web3, name, threshold, safeOwners }) {
     proposeRemoveSigner,
   } = web3;
   const verifiedSafeOwners = safeOwners.filter((so) => so.verified);
+  const onlyOneOwnerLeft = verifiedSafeOwners.length === 1;
   const onEditNameSubmit = (newName) => {
     modalContext.closeModal();
     setTreasury(address, { name: newName });
@@ -625,12 +626,14 @@ function SafeSettings({ address, web3, name, threshold, safeOwners }) {
                     ? "Copied"
                     : "Copy Address"}
                 </span>
-                <span
-                  className="is-underlined pointer"
-                  onClick={() => openRemoveOwnerModal(so)}
-                >
-                  Remove
-                </span>
+                {!onlyOneOwnerLeft && (
+                  <span
+                    className="is-underlined pointer"
+                    onClick={() => openRemoveOwnerModal(so)}
+                  >
+                    Remove
+                  </span>
+                )}
               </div>
             </div>
           ))}


### PR DESCRIPTION
## Description
<!-- What is this PR about -->
As per the requirements of this ticket https://linear.app/dappercollectives/issue/VSL-92/prevent-remove-button-if-only-one-owner-fe-work, adds logic to prevent rendering remove button when there's only one owner in the list
## Demo / Test Result
<!-- For FE changes, please attach screenshots/gif/video to show case the work -->
<!-- For Bug fix, please attach BEFORE & AFTER -->
<!-- For BE changes, how it's been verified? Unit test / E2E test result -->

https://user-images.githubusercontent.com/7423845/184389633-15092587-106c-497a-8fb5-3f80f00ed8c3.mov


