### PR TITLE
Update FlowGraph setup

### DIFF
--- a/packages/client/src/App.js
+++ b/packages/client/src/App.js
@@ -9,11 +9,8 @@ import { Logo, Navigation, Transactions } from "./components";
 const flowgraphClient = new GraphQLClient({
   url:
     process.env.REACT_APP_FLOW_ENV === "mainnet"
-      ? "https://query.flowgraph.co"
-      : "https://query.testnet.flowgraph.co",
-  headers: {
-    Authorization: `Bearer ${process.env.REACT_APP_FLOWGRAPH_API_KEY}`,
-  },
+      ? `https://query.flowgraph.co/?token=${process.env.REACT_APP_FLOWGRAPH_API_KEY}`
+      : `https://query.testnet.flowgraph.co/?token=${process.env.REACT_APP_FLOWGRAPH_API_KEY}`
 });
 
 const Wrapper = ({ children }) => <div className="App">{children}</div>;


### PR DESCRIPTION
## Description
<!-- What is this PR about -->
I was getting 401 invalid API token error from FlowGraph, turns out it was due to missing ENV with proper API key. 
After updating Fleek config with correct REACT_APP_FLOWGRAPH_API_KEY:
![Screen Shot 2022-08-15 at 10 38 31 AM](https://user-images.githubusercontent.com/105529038/184687419-756a7f88-4497-487c-9fcb-3bad0f25014b.png)

Getting CORS error:
![Screen Shot 2022-08-15 at 10 42 26 AM](https://user-images.githubusercontent.com/105529038/184687494-204cd06b-480e-44ca-a259-550dd9948249.png)

As per FlowGraph Doc, it's recommended to use frontend query string instead. So I updated the setup in this PR.
https://docs.flowgraph.co/#2-front-end-usage-url-query-string


## Demo / Test Result
<!-- For FE changes, please attach screenshots/gif/video to show case the work -->
<!-- For Bug fix, please attach BEFORE & AFTER -->
<!-- For BE changes, how it's been verified? Unit test / E2E test result -->
Not able to test it out as it doesn't work on emulator. Will verify it on stage.
