### PR TITLE
VSL-142: Enable signing with Lilico and Blocto

### DIFF
--- a/contracts/MyMultiSig.cdc
+++ b/contracts/MyMultiSig.cdc
@@ -361,9 +361,9 @@ pub contract MyMultiSigV2 {
             keyList.add(
                 PublicKey(
                     publicKey: accountKey.publicKey.publicKey,
-                    signatureAlgorithm: UInt(accountKey.publicKey.signatureAlgorithm.rawValue) == 2 ? SignatureAlgorithm.ECDSA_secp256k1  : SignatureAlgorithm.ECDSA_P256
+                    signatureAlgorithm: accountKey.publicKey.signatureAlgorithm
                 ),
-                hashAlgorithm: UInt(accountKey.hashAlgorithm.rawValue) == 3 ? HashAlgorithm.SHA3_256 : HashAlgorithm.SHA2_256,
+                hashAlgorithm: accountKey.hashAlgorithm,
                 weight: keyWeight
             )
 

--- a/contracts/MyMultiSig.cdc
+++ b/contracts/MyMultiSig.cdc
@@ -363,7 +363,7 @@ pub contract MyMultiSigV2 {
                     publicKey: accountKey.publicKey.publicKey,
                     signatureAlgorithm: UInt(accountKey.publicKey.signatureAlgorithm.rawValue) == 2 ? SignatureAlgorithm.ECDSA_secp256k1  : SignatureAlgorithm.ECDSA_P256
                 ),
-                hashAlgorithm: HashAlgorithm.SHA3_256,
+                hashAlgorithm: UInt(accountKey.hashAlgorithm.rawValue) == 3 ? HashAlgorithm.SHA3_256 : HashAlgorithm.SHA2_256,
                 weight: keyWeight
             )
 

--- a/packages/client/src/components/TestToolBox.js
+++ b/packages/client/src/components/TestToolBox.js
@@ -1,5 +1,5 @@
 import { useState, useContext, useEffect } from "react";
-import { Web3Context } from "contexts/Web3";
+import { createSignature, Web3Context } from "contexts/Web3";
 import { COIN_TYPES } from "constants/enums";
 const TestToolBox = ({ address }) => {
   const [showToolBox, setShowToolBox] = useState(false);
@@ -23,25 +23,10 @@ const TestToolBox = ({ address }) => {
     await initDepositTokensToTreasury();
   };
   const onDepositCollection = async () => {
-    const latestBlock = await injectedProvider
-      .send([injectedProvider.getBlock(true)])
-      .then(injectedProvider.decode);
 
-    const { height, id } = latestBlock;
-    const collectionIdHex = Buffer.from(
-      `A.${address.replace("0x", "")}.ExampleNFT.Collection`
-    ).toString("hex");
+    const collectionId = `A.${address.replace("0x", "")}.ExampleNFT.Collection`;
 
-    const message = `${collectionIdHex}${id}`;
-    const messageHex = Buffer.from(message).toString("hex");
-
-    let sigResponse = await injectedProvider
-      .currentUser()
-      .signUserMessage(messageHex);
-    const sigMessage =
-      sigResponse[0]?.signature?.signature ?? sigResponse[0]?.signature;
-    const keyIds = [sigResponse[0]?.keyId];
-    const signatures = [sigMessage];
+    const {message, keyIds, signatures, height} = await createSignature(collectionId);
 
     await sendCollectionToTreasury(
       address,

--- a/packages/client/src/contexts/Web3.js
+++ b/packages/client/src/contexts/Web3.js
@@ -68,7 +68,7 @@ export default function Web3Provider({
       Object.keys(contracts).forEach((contract) => {
         fcl.config().put(contract, contracts[contract]);
       });
-    } catch (e) {}
+    } catch (e) { }
   }, [network]);
 
   const user = useFclUser(fcl);
@@ -130,10 +130,16 @@ export const createSignature = async (intent) => {
     const messageHex = Buffer.from(message).toString("hex");
 
     let sigResponse = await fcl.currentUser().signUserMessage(messageHex);
-    const sigMessage =
-      sigResponse[0]?.signature?.signature ?? sigResponse[0]?.signature;
-    const keyIds = [sigResponse[0]?.keyId];
-    const signatures = [sigMessage];
+
+    let keyId = sigResponse[0].keyId;
+    let signature = sigResponse[0].signature;
+    // Temporary workaround for Blocto to send the correct key for signing the messages
+    if (sigResponse.length > 1 && sigResponse[1].keyId === 0) {
+      keyId = sigResponse[1].keyId;
+      signature = sigResponse[1].signature;
+    }
+    const keyIds = [keyId];
+    const signatures = [signature];
 
     return {
       message,

--- a/packages/client/src/hooks/useTreasury.js
+++ b/packages/client/src/hooks/useTreasury.js
@@ -75,10 +75,6 @@ const doProposeTransfer = async (
   coinType
 ) => {
   const uFixAmount = String(parseFloat(amount).toFixed(8));
-  const tokenAddress =
-    process.env.REACT_APP_FLOW_ENV === "emulator"
-      ? "ee82856bf20e2aa6"
-      : "9a0766d93b6608b7";
   const identifiers = await doQuery(GET_TREASURY_IDENTIFIERS, treasuryAddr);
   const recepientVault = getVaultId(identifiers, coinType);
   const intent = `Transfer ${uFixAmount} ${recepientVault} tokens from the treasury to ${recipientAddr}`;

--- a/packages/client/src/pages/Safe.js
+++ b/packages/client/src/pages/Safe.js
@@ -115,10 +115,17 @@ function Safe({ web3 }) {
     let sigResponse = await injectedProvider
       .currentUser()
       .signUserMessage(messageHex);
-    const sigMessage =
-      sigResponse[0]?.signature?.signature ?? sigResponse[0]?.signature;
-    const keyIds = [sigResponse[0]?.keyId];
-    const signatures = [sigMessage];
+
+    let keyId = sigResponse[0].keyId;
+    let signature = sigResponse[0].signature;
+    // Temporary workaround for Blocto to send the correct key for signing the messages
+    if (sigResponse.length > 1 && sigResponse[1].keyId === 0) {
+      keyId = sigResponse[1].keyId;
+      signature = sigResponse[1].signature;
+    }
+    const keyIds = [keyId];
+    const signatures = [signature];
+
     await signerApprove(
       parseInt(uuid, 10),
       message,


### PR DESCRIPTION
## Description
<!-- What is this PR about -->
Enabling signing with Lilico and Blocto
For Lilico the problem was verifying the hashing algorithm which is different than Blocto
For Blocto the problem was that on testnet it started returning both keys for signing the messages - temporary solution is to use the one with 999 weight, until we research how to send and validate both

## Demo / Test Result
`make test`