### PR TITLE
dont require name for loading safe

### DIFF
--- a/packages/client/src/pages/LoadSafe.js
+++ b/packages/client/src/pages/LoadSafe.js
@@ -16,12 +16,11 @@ const SafeHeader = ({
 }) => {
   let continueReady = false;
   if (safeName.trim().length && !isEmpty(safeOwners)) {
-    const everyOwnerHasName = safeOwners.every((so) => so?.name?.trim().length);
     const everyOwnerHasValidAddress = Object.values(
       safeOwnersValidByAddress
     ).every((isValid) => isValid);
 
-    if (everyOwnerHasName && everyOwnerHasValidAddress) {
+    if (everyOwnerHasValidAddress) {
       continueReady = true;
     }
   }
@@ -136,7 +135,7 @@ function LoadSafe({ web3 }) {
         <div className="column is-flex is-full" key={so.address}>
           <div className="flex-1 is-flex is-flex-direction-column pr-5">
             <label className="has-text-grey mb-2">
-              Owner Name<span className="has-text-red">*</span>
+              Owner Name
             </label>
             <input
               className="p-4 rounded-sm border-light"


### PR DESCRIPTION
remove the need to give a name to every signer when loading safe, removing the required asterisk and validation logic.