### PR TITLE
VSL 148: Safe Creating Page remains persistent after connecting with a new wallet bug

### DIFF
--- a/packages/client/src/hooks/useTreasury.js
+++ b/packages/client/src/hooks/useTreasury.js
@@ -334,7 +334,6 @@ export default function useTreasury(treasuryAddr) {
   }, [state.treasuries]);
 
   const createTreasury = async (treasuryData) => {
-    dispatch({ type: "SET_CREATING_TREASURY", payload: true });
     const { safeOwners, threshold } = treasuryData;
     const signerAddresses = safeOwners.map((is) => is.address);
     const creatorAddr = signerAddresses[0];
@@ -344,11 +343,7 @@ export default function useTreasury(treasuryAddr) {
     }
     await tx(res).onceSealed();
     setTreasury(creatorAddr, treasuryData);
-    dispatch({ type: "TREASURY_TRANSACTION_SUCCESS" });
     return res;
-  };
-  const cancelCreatingTreasury = () => {
-    dispatch({ type: "SET_CREATING_TREASURY", payload: false });
   };
   const setTreasury = (treasuryAddr, treasuryData) => {
     dispatch({
@@ -435,7 +430,6 @@ export default function useTreasury(treasuryAddr) {
     ...state,
     refreshTreasury,
     createTreasury,
-    cancelCreatingTreasury,
     fetchTreasury,
     setTreasury,
     proposeTransfer,

--- a/packages/client/src/pages/CreateSafe.js
+++ b/packages/client/src/pages/CreateSafe.js
@@ -17,7 +17,6 @@ const AuthorizeTreasury = ({
   safeOwners,
   safeOwnersValidByAddress,
   createTreasury,
-  cancelCreatingTreasury,
   creatingTreasury,
   createdTreasury,
   signersAmount,
@@ -51,7 +50,6 @@ const AuthorizeTreasury = ({
   };
   const onCancelCreatingSafe = () => {
     history.push("/");
-    cancelCreatingTreasury();
   };
   let stepMessage = "Create a new safe";
   if (creatingTreasury) stepMessage = "Your safe is being created...";
@@ -101,15 +99,14 @@ function CreateSafe({ web3 }) {
   const [safeType, setSafeType] = useState("Social");
   const [safeName, setSafeName] = useState("");
   const [signersAmount, setSignersAmount] = useState(1);
+  const [creatingTreasury, setCreatingTreasury] = useState(false);
+  const [createdTreasury, setCreatedTreasury] = useState(false);
   const {
     injectedProvider,
     address,
     loadingTreasuries,
-    creatingTreasury,
-    createdTreasury,
     submittedTransaction,
     createTreasury,
-    cancelCreatingTreasury,
   } = web3;
   const [safeOwners, setSafeOwners] = useState([
     { name: "", address, verified: true },
@@ -134,7 +131,11 @@ function CreateSafe({ web3 }) {
     // skip first safe owner since it's the connected user and won't have an address
     checkSafeOwnerAddressesValidity(newSafeOwners.slice(1));
   };
-
+  const onCreateTreasuryClick = async (treasuryData) => {
+    setCreatingTreasury(true);
+    await createTreasury(treasuryData);
+    setCreatedTreasury(true);
+  };
   if (!address) {
     return <WalletPrompt />;
   }
@@ -258,9 +259,8 @@ function CreateSafe({ web3 }) {
         safeOwners={safeOwners}
         safeOwnersValidByAddress={safeOwnersValidByAddress}
         signersAmount={signersAmount}
-        createTreasury={createTreasury}
+        createTreasury={onCreateTreasuryClick}
         creatingTreasury={creatingTreasury}
-        cancelCreatingTreasury={cancelCreatingTreasury}
         createdTreasury={createdTreasury}
       />
       {BodyComponents}

--- a/packages/client/src/reducers/treasuries.js
+++ b/packages/client/src/reducers/treasuries.js
@@ -1,8 +1,6 @@
 export const INITIAL_STATE = {
   loadingTreasuries: "Loading Treasuries",
   error: null,
-  creatingTreasury: false,
-  createdTreasury: false,
   submittedTransaction: false,
   treasuries: {},
   actions: {},
@@ -50,20 +48,10 @@ const reducer = (state, action) => {
         },
       };
     }
-    case "SET_CREATING_TREASURY":
-      return {
-        ...state,
-        creatingTreasury: action.payload,
-      };
     case "SUBMITTED_TREASURY_TRANSACTION":
       return {
         ...state,
         submittedTransaction: true,
-      };
-    case "TREASURY_TRANSACTION_SUCCESS":
-      return {
-        ...state,
-        createdTreasury: true,
       };
     case "SET_LOADING":
       return {


### PR DESCRIPTION
## Description
This pr fixes the bug of creating page persists after reconnect with a wallet

**Steps to Reproduce**

- With a connected Flow wallet, initiate safe creation by clicking the "create a new safe" button.
- Fill in the required information in the safe creation form and click the "sign & authorize" button.
- From the "Safe creating" processing page click the "Cancel" button.
- Once redirected to the landing page, disconnect from the current wallet and connect to a different wallet
- Re-initiate safe creation by clicking the "create a new safe"  button.

**Expected Behavior:**
User is presented with a new safe-create page.

**Actual Behavior:**
User is directed to the previous "Safe Creating" processing page. 


## Demo / Test Result

https://user-images.githubusercontent.com/7423845/187275720-cb4e9b40-c8a9-42ee-bbeb-8dfc384758b5.mov


