### PR TITLE
limit signature requirements to not exceed amount of safe owners

### DIFF
--- a/packages/client/src/components/SignatureRequirements.js
+++ b/packages/client/src/components/SignatureRequirements.js
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import React from "react";
 import ProgressBar from "./ProgressBar";
 import { Person, Minus, Plus } from "./Svg";
 import { getProgressPercentageForSignersAmount } from "../utils";
@@ -8,13 +8,6 @@ function SignatureRequirements({
   signersAmount,
   setSignersAmount,
 }) {
-  // force signer amount to not exceed amount of safe owners
-  useEffect(() => {
-    if (safeOwners.length < signersAmount) {
-      setSignersAmount(safeOwners.length);
-    }
-  }, [safeOwners]);
-
   const signerClasses = [
     "is-flex",
     "is-justify-content-center",

--- a/packages/client/src/components/SignatureRequirements.js
+++ b/packages/client/src/components/SignatureRequirements.js
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect } from "react";
 import ProgressBar from "./ProgressBar";
 import { Person, Minus, Plus } from "./Svg";
 import { getProgressPercentageForSignersAmount } from "../utils";
@@ -8,6 +8,13 @@ function SignatureRequirements({
   signersAmount,
   setSignersAmount,
 }) {
+  // force signer amount to not exceed amount of safe owners
+  useEffect(() => {
+    if (safeOwners.length < signersAmount) {
+      setSignersAmount(safeOwners.length);
+    }
+  }, [safeOwners]);
+
   const signerClasses = [
     "is-flex",
     "is-justify-content-center",

--- a/packages/client/src/pages/CreateSafe.js
+++ b/packages/client/src/pages/CreateSafe.js
@@ -129,6 +129,10 @@ function CreateSafe({ web3 }) {
     setSafeOwners(newSafeOwners);
     // skip first safe owner since it's the connected user and won't have an address
     checkSafeOwnerAddressesValidity(newSafeOwners.slice(1));
+    // force signer amount to not exceed amount of safe owners
+    if (newSafeOwners.length < signersAmount) {
+      setSignersAmount(newSafeOwners.length);
+    }
   };
   const onCreateTreasuryClick = async (treasuryData) => {
     setCreatingTreasury(true);


### PR DESCRIPTION
## Description
- limit the amount of signatures required to be no greater than the amount of safe owners added.


## Demo / Test Result

![image](https://user-images.githubusercontent.com/15314629/187993254-f0bb5060-d4ac-4239-892c-0129612932b5.png)
