### PR TITLE
VSL-98: Styling improvement and display success modal only for tokens and nfts

### DIFF
--- a/packages/client/src/modals/TransactionSuccessModal.js
+++ b/packages/client/src/modals/TransactionSuccessModal.js
@@ -68,7 +68,7 @@ const TransactionSuccessModal = ({ actionData, txID, onClose, safeName, safeAddr
             <div className="mt-4 border-light-top">
                 <div className="column is-vcentered is-multiline is-mobile border-light-bottom is-flex is-full">
                     <span className="flex-1 has-text-grey">Sent From</span>
-                    <div>
+                    <div className="flex-1">
                         <span className="has-text-weight-bold">
                             {safeName}
                         </span>
@@ -84,7 +84,7 @@ const TransactionSuccessModal = ({ actionData, txID, onClose, safeName, safeAddr
                 </div>
                 <div className="column is-vcentered is-multiline is-mobile border-light-bottom is-flex is-full">
                     <span className="has-text-grey flex-1">Sent To</span>
-                    <div>
+                    <div className="flex-1">
                         <span className="has-text-weight-bold">
                             {getSafeContactName(recipient)}
                         </span>

--- a/packages/client/src/pages/Safe.js
+++ b/packages/client/src/pages/Safe.js
@@ -15,6 +15,7 @@ import { ArrowDown, ArrowUp } from "../components/Svg";
 import { Web3Consumer, useModalContext } from "../contexts";
 import { useClipboard, useErrorMessage } from "../hooks";
 import { TransactionSuccessModal } from "modals";
+import { ACTION_TYPES } from "constants/enums";
 
 const ReceiveTokens = ({ name, address }) => {
   const modalContext = useModalContext();
@@ -78,18 +79,20 @@ function Safe({ web3 }) {
 
   const showTransactionSuccessModal = (action, safeName, safeAddress) => {
     const actionData = action.data.actionView;
-    openModal(
-      <TransactionSuccessModal
-        safeName={safeName}
-        safeAddress={safeAddress}
-        actionData={actionData}
-        txID={action.transactionId}
-        onClose={closeModal}
-      />,
-      {
-        headerTitle: "Success",
-      }
-    );
+    if (actionData.type === ACTION_TYPES.TRANSFER_NFT || actionData.type === ACTION_TYPES.TRANSFER_TOKEN) {
+      openModal(
+        <TransactionSuccessModal
+          safeName={safeName}
+          safeAddress={safeAddress}
+          actionData={actionData}
+          txID={action.transactionId}
+          onClose={closeModal}
+        />,
+        {
+          headerTitle: "Success",
+        }
+      );
+    }
   }
 
   const currentTab = tab ?? "home";


### PR DESCRIPTION
## Description
<!-- What is this PR about -->
This PR solves the issue of success modal showing up on every successful transaction
It is limited to showing only the success modals for sending NFT and tokens
The rest will be tackled as part of another task

Also adds the class flex-1 to fix the position of the contact address in case it is shorter than the other displayed (example in the demo/test result)

## Demo / Test Result
<!-- For FE changes, please attach screenshots/gif/video to show case the work -->
<!-- For Bug fix, please attach BEFORE & AFTER -->
<!-- For BE changes, how it's been verified? Unit test / E2E test result -->
<img width="443" alt="Screen Shot 2022-09-08 at 5 00 32 PM" src="https://user-images.githubusercontent.com/20346621/189245854-981ea0c8-19a7-4040-8600-0d91686da2fd.png">

