### PR TITLE
VSL-163: AddSignerUpdateThreshold and RemoveSignerUpdateThreshold actions

### DIFF
--- a/contracts/MyMultiSig.cdc
+++ b/contracts/MyMultiSig.cdc
@@ -161,7 +161,10 @@ pub contract MyMultiSigV4 {
         access(account) fun executeAction(actionUUID: UInt64, _ params: {String: AnyStruct}) {
             pre {
                 self.readyToExecute(actionUUID: actionUUID):
-                    "This action has not received a signature from every signer yet."
+                    "This action has not received a signature from every signer yet. Signed: "
+                        .concat(self.getTotalApprovedForAction(actionUUID: actionUUID).toString())
+                        .concat(" - Threshold: ")
+                        .concat(self.threshold.toString())
             }
             
             let action <- self.actions.remove(key: actionUUID) ?? panic("This action does not exist.")

--- a/contracts/TreasuryActions.cdc
+++ b/contracts/TreasuryActions.cdc
@@ -293,4 +293,83 @@ pub contract TreasuryActionsV4 {
       self.intent = "Update the threshold of signers to ".concat(threshold.toString()).concat(".")
     }
   }
+
+  pub struct AddSignerUpdateThreshold: MyMultiSigV4.Action {
+    pub let threshold: UInt
+    pub let signer: Address
+    pub let intent: String
+    pub let proposer: Address
+
+    access(account) fun execute(_ params: {String: AnyStruct}) {
+      let treasuryRef: &DAOTreasuryV4.Treasury = params["treasury"]! as! &DAOTreasuryV4.Treasury
+      let manager = treasuryRef.borrowManager()
+
+      // Add Signer
+      manager.addSigner(signer: self.signer)
+      log("\n\nEXECUTINGGGGG!!!!!!!!!\n\n")
+      // Update Threshold
+      manager.updateThreshold(newThreshold: self.threshold)
+    }
+
+    pub fun getView(): MyMultiSigV4.ActionView {
+      let view: MyMultiSigV4.ActionView = TreasuryActionsV4.InitializeActionView(
+        type: "AddSignerUpdateThreshold",
+        intent: self.intent,
+        proposer: self.proposer
+      )
+      view.newThreshold = self.threshold
+      view.signerAddr = self.signer
+      return view
+    }
+
+    init(signer: Address, threshold: UInt, proposer: Address) {
+      self.signer = signer
+      self.threshold = threshold
+      self.proposer = proposer
+      self.intent = "Add signer "
+        .concat(signer.toString())
+        .concat(". Update the threshold of signers to ")
+        .concat(threshold.toString()).concat(".")
+    }
+  }
+
+  pub struct RemoveSignerUpdateThreshold: MyMultiSigV4.Action {
+    pub let threshold: UInt
+    pub let signer: Address
+    pub let intent: String
+    pub let proposer: Address
+
+    access(account) fun execute(_ params: {String: AnyStruct}) {
+      let treasuryRef: &DAOTreasuryV4.Treasury = params["treasury"]! as! &DAOTreasuryV4.Treasury
+      let manager = treasuryRef.borrowManager()
+
+      // Remove Signer
+      manager.removeSigner(signer: self.signer)
+      // Update Threshold
+      manager.updateThreshold(newThreshold: self.threshold)
+    }
+
+    pub fun getView(): MyMultiSigV4.ActionView {
+      let view: MyMultiSigV4.ActionView = TreasuryActionsV4.InitializeActionView(
+        type: "RemoveSignerUpdateThreshold",
+        intent: self.intent,
+        proposer: self.proposer
+      )
+      view.newThreshold = self.threshold
+      view.signerAddr = self.signer
+      return view
+    }
+
+    init(signer: Address, threshold: UInt, proposer: Address) {
+      self.signer = signer
+      self.threshold = threshold
+      self.proposer = proposer
+      self.intent = "Remove signer "
+        .concat(signer.toString())
+        .concat(". Update the threshold of signers to ")
+        .concat(threshold.toString()).concat(".")
+    }
+  }
 }
+
+ 

--- a/contracts/TreasuryActions.cdc
+++ b/contracts/TreasuryActions.cdc
@@ -342,10 +342,10 @@ pub contract TreasuryActionsV4 {
       let treasuryRef: &DAOTreasuryV4.Treasury = params["treasury"]! as! &DAOTreasuryV4.Treasury
       let manager = treasuryRef.borrowManager()
 
-      // Remove Signer
-      manager.removeSigner(signer: self.signer)
       // Update Threshold
       manager.updateThreshold(newThreshold: self.threshold)
+      // Remove Signer
+      manager.removeSigner(signer: self.signer)
     }
 
     pub fun getView(): MyMultiSigV4.ActionView {

--- a/contracts/TreasuryActions.cdc
+++ b/contracts/TreasuryActions.cdc
@@ -306,7 +306,6 @@ pub contract TreasuryActionsV4 {
 
       // Add Signer
       manager.addSigner(signer: self.signer)
-      log("\n\nEXECUTINGGGGG!!!!!!!!!\n\n")
       // Update Threshold
       manager.updateThreshold(newThreshold: self.threshold)
     }

--- a/main_test.go
+++ b/main_test.go
@@ -603,10 +603,12 @@ func TestAddSignerUpdateThresholdAction(t *testing.T) {
 	var signers = []string{"treasuryOwner", "signer1", "signer2", "signer3"}
 
 	otu := NewOverflowTest(t)
-	otu.SetupTreasury("treasuryOwner", signers, len(signers))
+	originalThreshold := len(signers)
+	newThreshold := uint(len(signers) + 1)
+	otu.SetupTreasury("treasuryOwner", signers, originalThreshold)
 
 	t.Run("User should be able to propose a signer to be added", func(t *testing.T) {
-		otu.ProposeAddSignerUpdateThresholdAction("treasuryOwner", "treasuryOwner", "signer4", 1)
+		otu.ProposeAddSignerUpdateThresholdAction("treasuryOwner", "treasuryOwner", "signer4", newThreshold)
 	})
 
 	t.Run("Signers should be able to sign to approve a proposed action to add a new signer", func(t *testing.T) {
@@ -639,7 +641,7 @@ func TestAddSignerUpdateThresholdAction(t *testing.T) {
 		threshold := otu.GetTreasuryThreshold("treasuryOwner")
 
 		assert.Contains(otu.T, signers, otu.GetAccountAddress("signer4"))
-		assert.Equal(otu.T, 1, threshold)
+		assert.Equal(otu.T, newThreshold, uint(threshold))
 	})
 }
 
@@ -679,10 +681,12 @@ func TestRemoveSignerActionUpdateThreshold(t *testing.T) {
 	var removeSignerActionUUID uint64
 
 	otu := NewOverflowTest(t)
-	otu.SetupTreasury("treasuryOwner", Signers, 3)
+	originalThreshold := len(Signers)
+	newThreshold := uint(len(Signers) - 1)
+	otu.SetupTreasury("treasuryOwner", Signers, originalThreshold)
 
 	t.Run("User should be able to propose a signer to be removed", func(t *testing.T) {
-		otu.ProposeRemoveSignerUpdateThresholdAction("treasuryOwner", "treasuryOwner", "signer4", 1)
+		otu.ProposeRemoveSignerUpdateThresholdAction("treasuryOwner", "treasuryOwner", "signer4", newThreshold)
 	})
 
 	t.Run("Signers should be able to sign to approve a proposed action to remove a signer", func(t *testing.T) {
@@ -714,7 +718,7 @@ func TestRemoveSignerActionUpdateThreshold(t *testing.T) {
 		threshold := otu.GetTreasuryThreshold("treasuryOwner")
 
 		assert.NotContains(otu.T, signers, otu.GetAccountAddress("signer4"))
-		assert.Equal(otu.T, 1, threshold)
+		assert.Equal(otu.T, newThreshold, uint(threshold))
 	})
 }
 
@@ -752,7 +756,7 @@ func TestRemoveSignerActionErrors(t *testing.T) {
 	})
 
 	t.Run("A treasuryOwner shouldn't be able to execute a proposed action to remove a signer because the threshold will be higher than the number of signers", func(t *testing.T) {
-		otu.ExecuteActionFailed("treasuryOwner", removeSignerActionUUID, "Cannot remove signer, number of signers must be equal or higher than the threshold.")
+		otu.ExecuteActionFailed("treasuryOwner", removeSignerActionUUID, "Cannot update threshold, number of signers must be equal or higher than the threshold.")
 
 		signers := otu.GetTreasurySigners("treasuryOwner").String()
 

--- a/test_utils.go
+++ b/test_utils.go
@@ -556,9 +556,9 @@ func (otu *OverflowTestUtils) GetTreasuryThreshold(account string) int {
 	return int(threshold.ToGoValue().(uint64))
 }
 
-func (otu *OverflowTestUtils) ProposeAddSignerAction(treasuryAddr, proposingAcct, address string) *OverflowTestUtils {
+func (otu *OverflowTestUtils) ProposeAddSignerUpdateThresholdAction(treasuryAddr, proposingAcct, address string, threshold uint) *OverflowTestUtils {
 	signerAccount, _ := otu.O.State.Accounts().ByName(fmt.Sprintf("emulator-%s", address))
-	src := []byte(fmt.Sprintf("Add account 0x%s as a signer.", signerAccount.Address()))
+	src := []byte(fmt.Sprintf("Add signer 0x%s. Update the threshold of signers to %d.", signerAccount.Address(), threshold))
 	signerHex := make([]byte, hex.EncodedLen(len(src)))
 	hex.Encode(signerHex, src)
 
@@ -569,11 +569,12 @@ func (otu *OverflowTestUtils) ProposeAddSignerAction(treasuryAddr, proposingAcct
 	// signature
 	signature := otu.SignMessage(proposingAcct, message)
 
-	otu.O.TransactionFromFile("add_signer").
+	otu.O.TransactionFromFile("add_signer_update_threshold").
 		SignProposeAndPayAs(proposingAcct).
 		Args(otu.O.Arguments().
 			Address(treasuryAddr).
 			Address(address).
+			UInt(threshold).
 			String(message).
 			UInt64Array(0).
 			StringArray(signature).
@@ -584,9 +585,9 @@ func (otu *OverflowTestUtils) ProposeAddSignerAction(treasuryAddr, proposingAcct
 	return otu
 }
 
-func (otu *OverflowTestUtils) ProposeRemoveSignerAction(treasuryAddr, proposingAcct, address string) *OverflowTestUtils {
+func (otu *OverflowTestUtils) ProposeRemoveSignerUpdateThresholdAction(treasuryAddr, proposingAcct, address string, threshold uint) *OverflowTestUtils {
 	signerAccount, _ := otu.O.State.Accounts().ByName(fmt.Sprintf("emulator-%s", address))
-	src := []byte(fmt.Sprintf("Remove 0x%s as a signer.", signerAccount.Address()))
+	src := []byte(fmt.Sprintf("Remove signer 0x%s. Update the threshold of signers to %d.", signerAccount.Address(), threshold))
 	hexCollectionID := make([]byte, hex.EncodedLen(len(src)))
 	hex.Encode(hexCollectionID, src)
 
@@ -597,11 +598,12 @@ func (otu *OverflowTestUtils) ProposeRemoveSignerAction(treasuryAddr, proposingA
 	// signature
 	signature := otu.SignMessage(proposingAcct, message)
 
-	otu.O.TransactionFromFile("remove_signer").
+	otu.O.TransactionFromFile("remove_signer_update_threshold").
 		SignProposeAndPayAs(proposingAcct).
 		Args(otu.O.Arguments().
 			Address(treasuryAddr).
 			Address(address).
+			UInt(threshold).
 			String(message).
 			UInt64Array(0).
 			StringArray(signature).

--- a/transactions/add_signer_update_threshold.cdc
+++ b/transactions/add_signer_update_threshold.cdc
@@ -1,0 +1,30 @@
+import DAOTreasuryV4 from "../contracts/DAOTreasury.cdc"
+import TreasuryActionsV4 from "../contracts/TreasuryActions.cdc"
+import MyMultiSigV4 from "../contracts/MyMultiSig.cdc"
+
+transaction(treasuryAddr: Address, additionalSigner: Address, newThreshold: UInt, message: String, keyIds: [UInt64], signatures: [String], signatureBlock: UInt64) {
+  
+  let treasury: &DAOTreasuryV4.Treasury{DAOTreasuryV4.TreasuryPublic}
+  let action: AnyStruct{MyMultiSigV4.Action}
+  let messageSignaturePayload: MyMultiSigV4.MessageSignaturePayload
+
+  prepare(signer: AuthAccount) {
+    self.treasury = getAccount(treasuryAddr).getCapability(DAOTreasuryV4.TreasuryPublicPath)
+                    .borrow<&DAOTreasuryV4.Treasury{DAOTreasuryV4.TreasuryPublic}>()
+                    ?? panic("A DAOTreasuryV4 doesn't exist here.")
+    self.action = TreasuryActionsV4.AddSignerUpdateThreshold(signer: additionalSigner, threshold: newThreshold, proposer: signer.address)
+    
+    var _keyIds: [Int] = []
+
+    for keyId in keyIds {
+        _keyIds.append(Int(keyId))
+    }
+
+    self.messageSignaturePayload = MyMultiSigV4.MessageSignaturePayload(
+        signingAddr: signer.address, message: message, keyIds: _keyIds, signatures: signatures, signatureBlock: signatureBlock
+    )
+  }
+  execute {
+    self.treasury.proposeAction(action: self.action, signaturePayload: self.messageSignaturePayload)
+  }
+}

--- a/transactions/remove_signer_update_threshold.cdc
+++ b/transactions/remove_signer_update_threshold.cdc
@@ -1,0 +1,30 @@
+import DAOTreasuryV4 from "../contracts/DAOTreasury.cdc"
+import TreasuryActionsV4 from "../contracts/TreasuryActions.cdc"
+import MyMultiSigV4 from "../contracts/MyMultiSig.cdc"
+
+transaction(treasuryAddr: Address, signerToBeRemoved: Address, newThreshold: UInt, message: String, keyIds: [UInt64], signatures: [String], signatureBlock: UInt64) {
+  
+  let treasury: &DAOTreasuryV4.Treasury{DAOTreasuryV4.TreasuryPublic}
+  let action: AnyStruct{MyMultiSigV4.Action}
+  let messageSignaturePayload: MyMultiSigV4.MessageSignaturePayload
+
+  prepare(signer: AuthAccount) {
+    self.treasury = getAccount(treasuryAddr).getCapability(DAOTreasuryV4.TreasuryPublicPath)
+                    .borrow<&DAOTreasuryV4.Treasury{DAOTreasuryV4.TreasuryPublic}>()
+                    ?? panic("A DAOTreasuryV4 doesn't exist here.")
+    self.action = TreasuryActionsV4.RemoveSignerUpdateThreshold(signer: signerToBeRemoved, threshold: newThreshold, proposer: signer.address)
+    
+    var _keyIds: [Int] = []
+
+    for keyId in keyIds {
+        _keyIds.append(Int(keyId))
+    }
+
+    self.messageSignaturePayload = MyMultiSigV4.MessageSignaturePayload(
+        signingAddr: signer.address, message: message, keyIds: _keyIds, signatures: signatures, signatureBlock: signatureBlock
+    )
+  }
+  execute {
+    self.treasury.proposeAction(action: self.action, signaturePayload: self.messageSignaturePayload)
+  }
+}


### PR DESCRIPTION
## Description

- Adds `AddSignerUpdateThreshold` and `RemoveSignerUpdateThreshold` actions to `treasury_actions.cdc`
- Replace `TestAddSignerAction` test with `TestAddSignerUpdateThresholdAction`
- Replace `TestRemoveSignerAction` test with `TestRemoveSignerUpdateThresholdAction`

Now it is possible to add/remove a signer to/from a treasury AND update the threshold in the same action.

Once FE is integrated we can remove `AddSigner` and `RemoveSigner` actions.

## Demo / Test Result

`make test`
