### PR TITLE
VSL-166: return balance of 0 if user doesn't have a vault set up

### DIFF
--- a/packages/client/src/components/TestToolBox.js
+++ b/packages/client/src/components/TestToolBox.js
@@ -11,7 +11,7 @@ const TestToolBox = ({ address }) => {
   const { getUserBalances, initDepositTokensToTreasury } = useAccount();
   const { sendNFTToTreasury, getTreasuryCollections, balances, user } = web3;
 
-  const treasuryBalances = balances[address];
+  const treasuryBalances = balances?.[address];
   const onDeposit = async () => {
     await initDepositTokensToTreasury(address);
   };
@@ -80,9 +80,15 @@ const TestToolBox = ({ address }) => {
                 <li>
                   <span>Treasury:</span>
                   <ul className="ml-3">
-                    <li>Flow: {treasuryBalances[COIN_TYPES.FLOW]}</li>
-                    <li>FUSD: {treasuryBalances[COIN_TYPES.FUSD]}</li>
-                    <li>USDC: {treasuryBalances[COIN_TYPES.USDC]}</li>
+                    {treasuryBalances?.[COIN_TYPES.FLOW] && (
+                      <li>Flow: {treasuryBalances[COIN_TYPES.FLOW]}</li>
+                    )}
+                    {treasuryBalances?.[COIN_TYPES.FUSD] && (
+                      <li>FUSD: {treasuryBalances[COIN_TYPES.FUSD]}</li>
+                    )}
+                    {treasuryBalances?.[COIN_TYPES.USDC] && (
+                      <li>USDC: {treasuryBalances[COIN_TYPES.USDC]}</li>
+                    )}
                   </ul>
                 </li>
               </ul>

--- a/packages/client/src/flow/getAccountBalanceByContractName.tx.js
+++ b/packages/client/src/flow/getAccountBalanceByContractName.tx.js
@@ -6,9 +6,11 @@ export const GetAccountBalanceByContractName = (contractName) => `
         let account = getAccount(address)
 
         //this might break for contracts with configurable vault path
-        let vaultRef = account.getCapability(vaultPath)!
-            .borrow<&${contractName}.Vault{FungibleToken.Balance}>()
-            ?? panic("Could not borrow Balance reference to the Vault")
-
-        return vaultRef.balance
+        let vaultCap = getAccount(address).getCapability<&${contractName}.Vault{FungibleToken.Balance}>(vaultPath)
+        if vaultCap.check() {
+            let vaultRef: &${contractName}.Vault{FungibleToken.Balance} = vaultCap.borrow()??panic("Could not borrow Balance reference to the Vault")
+            return vaultRef.balance
+        } else{
+            return 0.00
+        }
     }`;


### PR DESCRIPTION
## Description
This pr fixes the front-end errors related to the testtoolbox
- Have the script return balance of 0 if user doesn't have a vault set up, to get rid of this error:
![Screen Shot 2022-09-14 at 3 08 54 PM](https://user-images.githubusercontent.com/7423845/190271698-c4c2f2a7-895f-4529-85c6-fb6d06fcdb50.png)

- conditional render the test tool box list items, to get rid of this error:
![Screen Shot 2022-09-14 at 3 09 32 PM](https://user-images.githubusercontent.com/7423845/190271770-e4204681-25cc-48ad-812d-2fa5e45867de.png)


## Demo / Test Result

<!-- For FE changes, please attach screenshots/gif/video to show case the work -->
<!-- For Bug fix, please attach BEFORE & AFTER -->
<!-- For BE changes, how it's been verified? Unit test / E2E test result -->
