### PR TITLE
reset default value of headerTitle when reusing modals

### DIFF
--- a/packages/client/src/contexts/Modal.js
+++ b/packages/client/src/contexts/Modal.js
@@ -49,6 +49,7 @@ const ModalProvider = ({ children }) => {
           closeOnBackgroundClick: true,
           showCloseButton: true,
           classNameModalContent: "",
+          headerTitle: "",
           ...customModalConfig,
         }));
       }

--- a/packages/client/src/contexts/Modal.js
+++ b/packages/client/src/contexts/Modal.js
@@ -41,18 +41,17 @@ const ModalProvider = ({ children }) => {
 
   const openModal = useCallback(
     (content, customModalConfig) => {
-      if (customModalConfig) {
-        setModalConfig(() => ({
-          ...modalConfig,
-          // set default values if modal is re-opened without configuration
-          // this is when two components are using the modal with different configuration at the same time
-          closeOnBackgroundClick: true,
-          showCloseButton: true,
-          classNameModalContent: "",
-          headerTitle: "",
-          ...customModalConfig,
-        }));
-      }
+      setModalConfig(() => ({
+        ...modalConfig,
+        // set default values if modal is re-opened without configuration
+        // this is when two components are using the modal with different configuration at the same time
+        closeOnBackgroundClick: true,
+        showCloseButton: true,
+        classNameModalContent: "",
+        headerTitle: "",
+        ...customModalConfig ?? {},
+      }));
+
       setContent(content);
       setModal(true);
     },


### PR DESCRIPTION
## Description

Fixes issue where once headerTitle is set, it gets appended to future modals because we're not clearing the modal state properly.

## Demo / Test Result

![image](https://user-images.githubusercontent.com/15314629/191298414-25d61e1b-0d09-4098-b954-439ee823491c.png)
